### PR TITLE
Add Markdown Editor for Editing Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ To customize robots.txt, modify the configuration under **RobotsTxt** section.
 
 Key | Description
 --- | ---
+Editor | HTML / Markdown
 CaptchaSettings:ImageWidth | Pixel Width of Captcha Image
 CaptchaSettings.ImageHeight | Pixel Height of Captcha Image
 PostSummaryWords | How may words to show in post list summary

--- a/src/Moonglade.Core/PostService.cs
+++ b/src/Moonglade.Core/PostService.cs
@@ -414,7 +414,10 @@ namespace Moonglade.Core
                     PostContent = AppSettings.Editor == EditorChoice.Markdown ?
                                     request.EditorContent :
                                     _htmlCodec.HtmlEncode(request.EditorContent),
-                    ContentAbstract = Utils.GetPostAbstract(request.EditorContent, AppSettings.PostSummaryWords),
+                    ContentAbstract = Utils.GetPostAbstract(
+                                            request.EditorContent, 
+                                            AppSettings.PostSummaryWords, 
+                                            AppSettings.Editor == EditorChoice.Markdown),
                     CreateOnUtc = DateTime.UtcNow,
                     Slug = request.Slug.ToLower().Trim(),
                     Title = request.Title.Trim(),
@@ -520,7 +523,10 @@ namespace Moonglade.Core
                 postModel.PostContent = AppSettings.Editor == EditorChoice.Markdown ? 
                                         request.EditorContent : 
                                         _htmlCodec.HtmlEncode(request.EditorContent);
-                postModel.ContentAbstract = Utils.GetPostAbstract(request.EditorContent, AppSettings.PostSummaryWords);
+                postModel.ContentAbstract = Utils.GetPostAbstract(
+                                            request.EditorContent, 
+                                            AppSettings.PostSummaryWords, 
+                                            AppSettings.Editor == EditorChoice.Markdown);
 
                 // Address #221: Do not allow published posts back to draft status
                 // postModel.PostPublish.IsPublished = request.IsPublished;

--- a/src/Moonglade.Core/PostService.cs
+++ b/src/Moonglade.Core/PostService.cs
@@ -43,7 +43,7 @@ namespace Moonglade.Core
             IRepository<PostPublishEntity> postPublishRepository,
             IRepository<CategoryEntity> categoryRepository,
             IRepository<PostCategoryEntity> postCategoryRepository,
-            IHtmlCodec htmlCodec, 
+            IHtmlCodec htmlCodec,
             IBlogConfig blogConfig) : base(logger, settings)
         {
             _postRepository = postRepository;
@@ -128,7 +128,7 @@ namespace Moonglade.Core
                     Id = p.Id,
                     Title = p.Title,
                     Slug = p.Slug,
-                    EncodedHtmlContent = p.PostContent,
+                    RawPostContent = p.PostContent,
                     ContentAbstract = p.ContentAbstract,
                     CommentEnabled = p.CommentEnabled,
                     CreateOnUtc = p.CreateOnUtc,
@@ -411,8 +411,10 @@ namespace Moonglade.Core
                 {
                     CommentEnabled = request.EnableComment,
                     Id = Guid.NewGuid(),
-                    PostContent = _htmlCodec.HtmlEncode(request.HtmlContent),
-                    ContentAbstract = Utils.GetPostAbstract(request.HtmlContent, AppSettings.PostSummaryWords),
+                    PostContent = AppSettings.Editor == EditorChoice.Markdown ?
+                                    request.EditorContent :
+                                    _htmlCodec.HtmlEncode(request.EditorContent),
+                    ContentAbstract = Utils.GetPostAbstract(request.EditorContent, AppSettings.PostSummaryWords),
                     CreateOnUtc = DateTime.UtcNow,
                     Slug = request.Slug.ToLower().Trim(),
                     Title = request.Title.Trim(),
@@ -515,8 +517,10 @@ namespace Moonglade.Core
                 }
 
                 postModel.CommentEnabled = request.EnableComment;
-                postModel.PostContent = _htmlCodec.HtmlEncode(request.HtmlContent);
-                postModel.ContentAbstract = Utils.GetPostAbstract(request.HtmlContent, AppSettings.PostSummaryWords);
+                postModel.PostContent = AppSettings.Editor == EditorChoice.Markdown ? 
+                                        request.EditorContent : 
+                                        _htmlCodec.HtmlEncode(request.EditorContent);
+                postModel.ContentAbstract = Utils.GetPostAbstract(request.EditorContent, AppSettings.PostSummaryWords);
 
                 // Address #221: Do not allow published posts back to draft status
                 // postModel.PostPublish.IsPublished = request.IsPublished;

--- a/src/Moonglade.Core/Utils.cs
+++ b/src/Moonglade.Core/Utils.cs
@@ -366,10 +366,18 @@ namespace Moonglade.Core
             return newStr;
         }
 
-        public static string MdContentToHtml(string markdown)
+        public static string MdContentToHtml(string markdown, bool disableHtml = true)
         {
-            var pipeline = new MarkdownPipelineBuilder().DisableHtml().Build();
-            var result = Markdown.ToHtml(markdown, pipeline);
+            var pipeline = new MarkdownPipelineBuilder()
+                               .UsePipeTables()
+                               .UseBootstrap();
+
+            if (disableHtml)
+            {
+                pipeline.DisableHtml();
+            }
+
+            var result = Markdown.ToHtml(markdown, pipeline.Build());
             return result;
         }
 

--- a/src/Moonglade.Core/Utils.cs
+++ b/src/Moonglade.Core/Utils.cs
@@ -199,9 +199,12 @@ namespace Moonglade.Core
             return null != tz ? TimeZoneInfo.ConvertTimeFromUtc(utcTime, tz) : utcTime.AddTicks(span.Ticks);
         }
 
-        public static string GetPostAbstract(string rawHtmlContent, int wordCount)
+        public static string GetPostAbstract(string rawContent, int wordCount, bool useMarkdown = false)
         {
-            var plainText = RemoveTags(rawHtmlContent);
+            var plainText = useMarkdown ?
+                            ConvertMarkdownContent(rawContent, MarkdownConvertType.Text) :
+                            RemoveTags(rawContent);
+
             var result = plainText.Ellipsize(wordCount);
             return result;
         }
@@ -366,19 +369,48 @@ namespace Moonglade.Core
             return newStr;
         }
 
-        public static string MdContentToHtml(string markdown, bool disableHtml = true)
+        public static string ConvertMarkdownContent(string markdown, MarkdownConvertType type, bool disableHtml = true)
         {
-            var pipeline = new MarkdownPipelineBuilder()
-                               .UsePipeTables()
-                               .UseBootstrap();
+            var pipeline = GetMoongladeMarkdownPipelineBuilder();
 
             if (disableHtml)
             {
                 pipeline.DisableHtml();
             }
 
-            var result = Markdown.ToHtml(markdown, pipeline.Build());
+            string result;
+            switch (type)
+            {
+                case MarkdownConvertType.None:
+                    result = markdown;
+                    break;
+                case MarkdownConvertType.Html:
+                    result = Markdown.ToHtml(markdown, pipeline.Build());
+                    break;
+                case MarkdownConvertType.Text:
+                    result = Markdown.ToPlainText(markdown, pipeline.Build());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+
             return result;
+        }
+
+        public enum MarkdownConvertType
+        {
+            None = 0,
+            Html = 1,
+            Text = 2
+        }
+
+        private static MarkdownPipelineBuilder GetMoongladeMarkdownPipelineBuilder()
+        {
+            var pipeline = new MarkdownPipelineBuilder()
+                .UsePipeTables()
+                .UseBootstrap();
+
+            return pipeline;
         }
 
         public static Response<(string Slug, DateTime PubDate)> GetSlugInfoFromPostUrl(string url)

--- a/src/Moonglade.Model/CreateEditPostRequest.cs
+++ b/src/Moonglade.Model/CreateEditPostRequest.cs
@@ -6,7 +6,7 @@ namespace Moonglade.Model
     {
         public string Title { get; set; }
         public string Slug { get; set; }
-        public string HtmlContent { get; set; }
+        public string EditorContent { get; set; }
         public bool EnableComment { get; set; }
         public bool IsPublished { get; set; }
         public bool ExposedToSiteMap { get; set; }

--- a/src/Moonglade.Model/Post.cs
+++ b/src/Moonglade.Model/Post.cs
@@ -9,7 +9,7 @@ namespace Moonglade.Model
         public Guid Id { get; set; }
         public string Title { get; set; }
         public string Slug { get; set; }
-        public string EncodedHtmlContent { get; set; }
+        public string RawPostContent { get; set; }
         public bool CommentEnabled { get; set; }
         public DateTime CreateOnUtc { get; set; }
         public string ContentAbstract { get; set; }

--- a/src/Moonglade.Model/Settings/AppSettings.cs
+++ b/src/Moonglade.Model/Settings/AppSettings.cs
@@ -4,11 +4,19 @@ namespace Moonglade.Model.Settings
 {
     public class AppSettings
     {
+        public EditorChoice Editor { get; set; }
         public CaptchaSettings CaptchaSettings { get; set; }
         public int PostSummaryWords { get; set; }
         public int ImageCacheSlidingExpirationMinutes { get; set; }
         public bool AllowScriptsInCustomPage { get; set; }
 
         public NotificationSettings Notification { get; set; }
+    }
+
+    public enum EditorChoice
+    {
+        None = 0,
+        HTML = 1,
+        Markdown = 2
     }
 }

--- a/src/Moonglade.Tests/UtilsTests.cs
+++ b/src/Moonglade.Tests/UtilsTests.cs
@@ -102,7 +102,7 @@ namespace Moonglade.Tests
         public void TestMdContentToHtml()
         {
             string md = "A quick brown **fox** jumped over the lazy dog.";
-            string result = Utils.MdContentToHtml(md);
+            string result = Utils.ConvertMarkdownContent(md, Utils.MarkdownConvertType.Html);
 
             Assert.IsTrue(result == "<p>A quick brown <strong>fox</strong> jumped over the lazy dog.</p>\n");
         }

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -75,7 +75,7 @@ namespace Moonglade.Web.Controllers
                         {
                             _ = Task.Run(async () =>
                               {
-                                  await _notificationClient.SendNewCommentNotificationAsync(response.Item, s => Utils.MdContentToHtml(s));
+                                  await _notificationClient.SendNewCommentNotificationAsync(response.Item, s => Utils.ConvertMarkdownContent(s, Utils.MarkdownConvertType.Html));
                               });
                         }
                         var cResponse = new CommentResponse(true,

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -30,7 +30,7 @@ namespace Moonglade.Web.Controllers
             ILogger<CommentController> logger,
             IOptions<AppSettings> settings,
             CommentService commentService,
-            IBlogConfig blogConfig, 
+            IBlogConfig blogConfig,
             IMoongladeNotificationClient notificationClient = null)
             : base(logger, settings)
         {
@@ -75,12 +75,12 @@ namespace Moonglade.Web.Controllers
                         {
                             _ = Task.Run(async () =>
                               {
-                                  await _notificationClient.SendNewCommentNotificationAsync(response.Item, Utils.MdContentToHtml);
+                                  await _notificationClient.SendNewCommentNotificationAsync(response.Item, s => Utils.MdContentToHtml(s));
                               });
                         }
-                        var cResponse = new CommentResponse(true, 
-                            _blogConfig.ContentSettings.RequireCommentReview ? 
-                            CommentResponseCode.Success : 
+                        var cResponse = new CommentResponse(true,
+                            _blogConfig.ContentSettings.RequireCommentReview ?
+                            CommentResponseCode.Success :
                             CommentResponseCode.SuccessNonReview);
 
                         return Json(cResponse);

--- a/src/Moonglade.Web/Controllers/PostController.Manage.cs
+++ b/src/Moonglade.Web/Controllers/PostController.Manage.cs
@@ -49,6 +49,8 @@ namespace Moonglade.Web.Controllers
         public async Task<IActionResult> Create()
         {
             var view = await GetCreatePostModelAsync();
+            
+            ViewBag.EditorMode = AppSettings.Editor;
             return View("CreateOrEdit", view);
         }
 
@@ -102,6 +104,7 @@ namespace Moonglade.Web.Controllers
                     editViewModel.CategoryList = cbCatList;
                 }
 
+                ViewBag.EditorMode = AppSettings.Editor;
                 return View("CreateOrEdit", editViewModel);
             }
 

--- a/src/Moonglade.Web/Controllers/PostController.Manage.cs
+++ b/src/Moonglade.Web/Controllers/PostController.Manage.cs
@@ -49,8 +49,6 @@ namespace Moonglade.Web.Controllers
         public async Task<IActionResult> Create()
         {
             var view = await GetCreatePostModelAsync();
-            
-            ViewBag.EditorMode = AppSettings.Editor;
             return View("CreateOrEdit", view);
         }
 
@@ -71,7 +69,9 @@ namespace Moonglade.Web.Controllers
                 {
                     PostId = post.Id,
                     IsPublished = post.IsPublished,
-                    HtmlContent = htmlCodec.HtmlDecode(post.EncodedHtmlContent),
+                    EditorContent = AppSettings.Editor == Model.Settings.EditorChoice.Markdown ? 
+                                                        post.RawPostContent : 
+                                                        htmlCodec.HtmlDecode(post.RawPostContent),
                     Slug = post.Slug,
                     Title = post.Title,
                     EnableComment = post.CommentEnabled,
@@ -104,7 +104,6 @@ namespace Moonglade.Web.Controllers
                     editViewModel.CategoryList = cbCatList;
                 }
 
-                ViewBag.EditorMode = AppSettings.Editor;
                 return View("CreateOrEdit", editViewModel);
             }
 
@@ -131,7 +130,7 @@ namespace Moonglade.Web.Controllers
                     {
                         Title = model.Title.Trim(),
                         Slug = model.Slug.Trim(),
-                        HtmlContent = model.HtmlContent,
+                        EditorContent = model.EditorContent,
                         EnableComment = model.EnableComment,
                         ExposedToSiteMap = model.ExposedToSiteMap,
                         IsFeedIncluded = model.FeedIncluded,

--- a/src/Moonglade.Web/Models/PostEditViewModel.cs
+++ b/src/Moonglade.Web/Models/PostEditViewModel.cs
@@ -33,7 +33,7 @@ namespace Moonglade.Web.Models
         [Required(ErrorMessage = "Please enter content.")]
         [JsonIgnore]
         [DataType(DataType.MultilineText)]
-        public string HtmlContent { get; set; }
+        public string EditorContent { get; set; }
 
         [Required]
         [Display(Name = "Publish Now")]

--- a/src/Moonglade.Web/Views/Comment/Manage.cshtml
+++ b/src/Moonglade.Web/Views/Comment/Manage.cshtml
@@ -92,7 +92,7 @@ else
                     @item.Username (<a href="mailto:@item.Email" class="d-none d-sm-inline">@item.Email</a>)
                 </h6>
                 <div class="mdrendered-comment-content">
-                    @Html.Raw(Utils.MdContentToHtml(item.CommentContent))
+                    @Html.Raw(Utils.ConvertMarkdownContent(item.CommentContent, Utils.MarkdownConvertType.Html))
                 </div>
                 <div class="text-muted">
                     @item.PostTitle

--- a/src/Moonglade.Web/Views/Post/CreateOrEdit.cshtml
+++ b/src/Moonglade.Web/Views/Post/CreateOrEdit.cshtml
@@ -12,26 +12,49 @@
             box-shadow: inherit;
         }
 
-        .bootstrap-tagsinput .tag {
-            background: #2a579a;
-            padding: 2px 5px;
-        }
+            .bootstrap-tagsinput .tag {
+                background: #2a579a;
+                padding: 2px 5px;
+            }
 
-        .bootstrap-tagsinput .tag [data-role="remove"]:hover {
-            box-shadow: inherit;
-        }
+                .bootstrap-tagsinput .tag [data-role="remove"]:hover {
+                    box-shadow: inherit;
+                }
     </style>
 }
 @section scripts{
     <script src="~/lib/typeahead.js/typeahead.bundle.min.js"></script>
     <script src="~/lib/bootstrap-tagsinput/bootstrap-tagsinput.min.js"></script>
-    <script src="~/lib/tinymce/tinymce.min.js"></script>
+    @{
+        var ec = (EditorChoice)ViewBag.EditorMode;
+        switch (ec)
+        {
+            case EditorChoice.HTML:
+                <script src="~/lib/tinymce/tinymce.min.js"></script>
+                break;
+            case EditorChoice.Markdown:
+                <script src="~/lib/simplemde/simplemde.min.js"></script>
+                <link id="css-simplemde" href="~/lib/simplemde/simplemde.min.css" rel="stylesheet" />
+                break;
+            case EditorChoice.None:
+            default:
+                break;
+        }
+    }
     <script src="~/lib/jquery.AreYouSure/jquery.are-you-sure.min.js"></script>
 
     <script>
         $(function () {
             postEditor.initEvents();
-            postEditor.loadRichEditor(".post-content-textarea");
+            var editorMode = '@ViewBag.EditorMode';
+            if (editorMode == 'HTML') {
+                postEditor.loadRichEditor(".post-content-textarea");
+            }
+            if (editorMode == 'Markdown') {
+                postEditor.loadMdEditor(".post-content-textarea");
+
+            }
+
             postEditor.keepAlive();
         });
     </script>

--- a/src/Moonglade.Web/Views/Post/CreateOrEdit.cshtml
+++ b/src/Moonglade.Web/Views/Post/CreateOrEdit.cshtml
@@ -26,7 +26,7 @@
     <script src="~/lib/typeahead.js/typeahead.bundle.min.js"></script>
     <script src="~/lib/bootstrap-tagsinput/bootstrap-tagsinput.min.js"></script>
     @{
-        var ec = (EditorChoice)ViewBag.EditorMode;
+        var ec = Settings.Value.Editor;
         switch (ec)
         {
             case EditorChoice.HTML:
@@ -46,7 +46,7 @@
     <script>
         $(function () {
             postEditor.initEvents();
-            var editorMode = '@ViewBag.EditorMode';
+            var editorMode = '@Settings.Value.Editor';
             if (editorMode == 'HTML') {
                 postEditor.loadRichEditor(".post-content-textarea");
             }
@@ -96,9 +96,9 @@
             </div>
 
             <div class="form-group">
-                <textarea asp-for="HtmlContent" class="post-content-textarea"></textarea>
+                <textarea asp-for="EditorContent" class="post-content-textarea"></textarea>
                 <div>
-                    <span asp-validation-for="HtmlContent" class="text-danger"></span>
+                    <span asp-validation-for="EditorContent" class="text-danger"></span>
                 </div>
             </div>
 

--- a/src/Moonglade.Web/Views/Post/Slug.cshtml
+++ b/src/Moonglade.Web/Views/Post/Slug.cshtml
@@ -186,7 +186,7 @@
         @switch (ec)
         {
             case EditorChoice.Markdown:
-                @Html.Raw(Utils.MdContentToHtml(Model.PostModel.Content, false))
+                @Html.Raw(Utils.ConvertMarkdownContent(Model.PostModel.Content, Utils.MarkdownConvertType.Html, false))
                 break;
             case EditorChoice.None:
             case EditorChoice.HTML:

--- a/src/Moonglade.Web/Views/Post/Slug.cshtml
+++ b/src/Moonglade.Web/Views/Post/Slug.cshtml
@@ -186,7 +186,7 @@
         @switch (ec)
         {
             case EditorChoice.Markdown:
-                @Html.Raw(Utils.MdContentToHtml(Model.PostModel.Content))
+                @Html.Raw(Utils.MdContentToHtml(Model.PostModel.Content, false))
                 break;
             case EditorChoice.None:
             case EditorChoice.HTML:

--- a/src/Moonglade.Web/Views/Post/Slug.cshtml
+++ b/src/Moonglade.Web/Views/Post/Slug.cshtml
@@ -5,6 +5,7 @@
 
 @{
     ViewBag.ShowBloggerIntroInXS = true;
+    var ec = Settings.Value.Editor;
 }
 
 @section keywords {
@@ -182,7 +183,17 @@
         <hr class="post-header-hr" />
     </header>
     <section class="post-content clearfix">
-        @Html.Raw(Model.PostModel.Content)
+        @switch (ec)
+        {
+            case EditorChoice.Markdown:
+                @Html.Raw(Utils.MdContentToHtml(Model.PostModel.Content))
+                break;
+            case EditorChoice.None:
+            case EditorChoice.HTML:
+            default:
+                @Html.Raw(Model.PostModel.Content)
+                break;
+        }
     </section>
     @if (null == ViewBag.IsDraftPreview)
     {

--- a/src/Moonglade.Web/Views/Shared/Components/CommentList/Default.cshtml
+++ b/src/Moonglade.Web/Views/Shared/Components/CommentList/Default.cshtml
@@ -45,7 +45,7 @@
                         <span class="text-muted float-right"> @Utils.UtcToZoneTime(item.CreateOnUtc, BlogConfig.GeneralSettings.TimeZoneUtcOffset).ToString("yyyy-M-d HH:mm")</span>
                     </div>
                     <div class="card-body">
-                        @Html.Raw(Utils.MdContentToHtml(item.CommentContent))
+                        @Html.Raw(Utils.ConvertMarkdownContent(item.CommentContent, Utils.MarkdownConvertType.Html))
                         <div>
                             @foreach (var reply in item.CommentReplies.OrderByDescending(t => t.ReplyTimeUtc))
                             {

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -37,6 +37,7 @@
     }
   },
   "AppSettings": {
+    "Editor": "HTML",
     "CaptchaSettings": {
       "ImageWidth": 100,
       "ImageHeight": 36

--- a/src/Moonglade.Web/wwwroot/css/src/admin.css
+++ b/src/Moonglade.Web/wwwroot/css/src/admin.css
@@ -31,6 +31,10 @@ hr.admin-nav-divider {
     min-height: 650px;
 }
 
+.post-edit-form .CodeMirror {
+    height: 620px;
+}
+
 .admin-nav-section .list-group-item {
     background-color: transparent;
     border: 0 none;

--- a/src/Moonglade.Web/wwwroot/css/src/admin.css
+++ b/src/Moonglade.Web/wwwroot/css/src/admin.css
@@ -27,6 +27,10 @@ hr.admin-nav-divider {
     color: #98abc7;
 }
 
+.post-content-textarea {
+    min-height: 650px;
+}
+
 .admin-nav-section .list-group-item {
     background-color: transparent;
     border: 0 none;

--- a/src/Moonglade.Web/wwwroot/css/src/moonglade-base.css
+++ b/src/Moonglade.Web/wwwroot/css/src/moonglade-base.css
@@ -5,7 +5,7 @@
     border-top-right-radius: 0 !important;
 }
 
-.CodeMirror {
+.comment-md-content .CodeMirror {
     border-bottom: 1px solid #ddd !important;
     border-left: 0 none !important;
     border-right: 0 none !important;

--- a/src/Moonglade.Web/wwwroot/js/app/admin.js
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.js
@@ -47,6 +47,15 @@ var postEditor = {
             });
         }
     },
+    loadMdEditor: function (textareaSelector) {
+        if (window.SimpleMDE) {
+            var simplemde = new SimpleMDE({
+                element: $(textareaSelector)[0],
+                spellChecker: false,
+                status: false
+            });
+        }
+    },
     initEvents: function () {
         $('#Title').change(function () {
             $('#Slug').val(slugify($(this).val()));

--- a/src/Moonglade.Web/wwwroot/js/app/admin.js
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.js
@@ -112,7 +112,9 @@ var postEditor = {
         });
 
         function submitForm(e) {
-            window.tinyMCE.triggerSave();
+            if (window.tinyMCE) {
+                window.tinyMCE.triggerSave();
+            }
 
             var selectCatCount = 0;
             $('input[name="SelectedCategoryIds"]').each(function () {

--- a/src/Moonglade.Web/wwwroot/js/app/admin.js
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.js
@@ -18,7 +18,7 @@ var postEditor = {
                 selector: textareaSelector,
                 themes: 'silver',
                 skin: 'oxide',
-                height: 650,
+                //height: 650,
                 relative_urls: false, // avoid image upload fuck up
                 browser_spellcheck: true,
                 branding: false,


### PR DESCRIPTION
Allow users to choose between HTML (TinyMCE) or Markdown (SimpleMDE) editor for their blog content. Address #304 

This is in preview and may be buggy. Please send feedback under this PR.