### PR TITLE
Add Environment Tags

### DIFF
--- a/src/Moonglade.Core/Utils.cs
+++ b/src/Moonglade.Core/Utils.cs
@@ -436,7 +436,7 @@ namespace Moonglade.Core
                 yield break;
             }
 
-            var tagRegex = new Regex("(?!-)([a-z0-9-]+)");
+            var tagRegex = new Regex(@"^[a-zA-Z0-9-#@$()\[\]/]+$");
             var tags = tagsEnv.Split(',');
             foreach (string tag in tags)
             {

--- a/src/Moonglade.Core/Utils.cs
+++ b/src/Moonglade.Core/Utils.cs
@@ -426,5 +426,17 @@ namespace Moonglade.Core
             Html = 1,
             Text = 2
         }
+
+        public static IEnumerable<string> GetEnvironmentTags()
+        {
+            var tagsEnv = Environment.GetEnvironmentVariable("MOONGLADE_TAGS");
+            if (string.IsNullOrWhiteSpace(tagsEnv))
+            {
+                return new[] { string.Empty };
+            }
+
+            var tags = tagsEnv.Split(',').Select(p => p.Trim());
+            return tags;
+        }
     }
 }

--- a/src/Moonglade.Core/Utils.cs
+++ b/src/Moonglade.Core/Utils.cs
@@ -432,11 +432,20 @@ namespace Moonglade.Core
             var tagsEnv = Environment.GetEnvironmentVariable("MOONGLADE_TAGS");
             if (string.IsNullOrWhiteSpace(tagsEnv))
             {
-                return new[] { string.Empty };
+                yield return string.Empty;
+                yield break;
             }
 
-            var tags = tagsEnv.Split(',').Select(p => p.Trim());
-            return tags;
+            var tagRegex = new Regex("(?!-)([a-z0-9-]+)");
+            var tags = tagsEnv.Split(',');
+            foreach (string tag in tags)
+            {
+                var t = tag.Trim();
+                if (tagRegex.IsMatch(t))
+                {
+                    yield return t;
+                }
+            }
         }
     }
 }

--- a/src/Moonglade.Tests/UtilsTests.cs
+++ b/src/Moonglade.Tests/UtilsTests.cs
@@ -335,5 +335,23 @@ namespace Moonglade.Tests
                 Utils.ResolveCanonicalUrl("996ICU", "251");
             });
         }
+
+        [TestCase("")]
+        [TestCase("DC1")]
+        [TestCase("DC1,DC2")]
+        [TestCase("DC1, DC2")]
+        [TestCase("DC1, DC2,DC3")]
+        public void TestGetEnvironmentTags(string tags)
+        {
+            Environment.SetEnvironmentVariable("MOONGLADE_TAGS", tags, EnvironmentVariableTarget.Process);
+            var envTags = Utils.GetEnvironmentTags();
+            Assert.IsNotNull(envTags);
+
+            var list = tags.Split(',').Select(p => p.Trim());
+            foreach (var tag in list)
+            {
+                Assert.IsTrue(envTags.Contains(tag));
+            }
+        }
     }
 }

--- a/src/Moonglade.Tests/UtilsTests.cs
+++ b/src/Moonglade.Tests/UtilsTests.cs
@@ -341,6 +341,7 @@ namespace Moonglade.Tests
         [TestCase("DC1,DC2")]
         [TestCase("DC1, DC2")]
         [TestCase("DC1, DC2,DC3")]
+        [TestCase("DC[1], DC-2, DC#3, DC@4, DC$5, DC(6), DC/7")]
         public void TestGetEnvironmentTagsValid(string tags)
         {
             Environment.SetEnvironmentVariable("MOONGLADE_TAGS", tags, EnvironmentVariableTarget.Process);
@@ -352,6 +353,29 @@ namespace Moonglade.Tests
             {
                 Assert.IsTrue(envTags.Contains(tag));
             }
+        }
+
+        [TestCase("DC%1")]
+        [TestCase("DC 1")]
+        [TestCase("DC*1")]
+        [TestCase("DC^1")]
+        [TestCase("DC^1")]
+        [TestCase("DC+1")]
+        [TestCase("DC=1")]
+        [TestCase("DC!1")]
+        [TestCase("DC`1")]
+        [TestCase("DC~1")]
+        [TestCase("DC'1")]
+        [TestCase("DC?1")]
+        [TestCase("DC{1}")]
+        public void TestGetEnvironmentTagsInvalid(string invalidTag)
+        {
+            Environment.SetEnvironmentVariable("MOONGLADE_TAGS", $"DC1, DC2, {invalidTag}", EnvironmentVariableTarget.Process);
+            var envTags = Utils.GetEnvironmentTags();
+            Assert.IsNotNull(envTags);
+
+            Assert.IsTrue(envTags.Count() == 2);
+            Assert.IsTrue(!envTags.Contains(invalidTag));
         }
     }
 }

--- a/src/Moonglade.Tests/UtilsTests.cs
+++ b/src/Moonglade.Tests/UtilsTests.cs
@@ -341,7 +341,7 @@ namespace Moonglade.Tests
         [TestCase("DC1,DC2")]
         [TestCase("DC1, DC2")]
         [TestCase("DC1, DC2,DC3")]
-        public void TestGetEnvironmentTags(string tags)
+        public void TestGetEnvironmentTagsValid(string tags)
         {
             Environment.SetEnvironmentVariable("MOONGLADE_TAGS", tags, EnvironmentVariableTarget.Process);
             var envTags = Utils.GetEnvironmentTags();

--- a/src/Moonglade.Web/Properties/launchSettings.json
+++ b/src/Moonglade.Web/Properties/launchSettings.json
@@ -24,7 +24,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "MOONGLADE_TAGS": "local, dev"
       },
       "applicationUrl": "https://localhost:1055;http://localhost:1050"
     }

--- a/src/Moonglade.Web/Startup.cs
+++ b/src/Moonglade.Web/Startup.cs
@@ -255,8 +255,15 @@ namespace Moonglade.Web
                 endpoints.MapGet("/ping", async context =>
                 {
                     context.Response.Headers.Add("X-Moonglade-Version", Utils.AppVersion);
-                    await context.Response.WriteAsync(
-                        $"Moonglade Version: {Utils.AppVersion}, .NET Core {Environment.Version}", Encoding.UTF8);
+                    var obj = new
+                    {
+                        MoongladeVersion = Utils.AppVersion,
+                        DotNetVersion = Environment.Version.ToString(),
+                        EnvironmentTags = Utils.GetEnvironmentTags()
+                    };
+
+                    var json = System.Text.Json.JsonSerializer.Serialize(obj);
+                    await context.Response.WriteAsync(json, Encoding.UTF8);
                 });
                 endpoints.MapControllerRoute(
                     "default",


### PR DESCRIPTION
Allow user to set tags to `MOONGLADE_TAGS` environment variable, so that deployment across multiple servers can be easily identified.