### PR TITLE
Add code coverage badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # 🌕 Moonglade
 
-[![Build Status](https://dev.azure.com/ediwang/Edi-GitHub/_apis/build/status/EdiWang.Moonglade?branchName=master)](https://dev.azure.com/ediwang/Edi-GitHub/_build/latest?definitionId=68&branchName=master) ![Docker Build and Push](https://github.com/EdiWang/Moonglade/workflows/Docker%20Build%20and%20Push/badge.svg) ![.NET Build Linux](https://github.com/EdiWang/Moonglade/workflows/.NET%20Build%20Linux/badge.svg)
+[![Build Status](https://dev.azure.com/ediwang/Edi-GitHub/_apis/build/status/EdiWang.Moonglade?branchName=master)](https://dev.azure.com/ediwang/Edi-GitHub/_build/latest?definitionId=68&branchName=master) 
+![Code Coverage](https://img.shields.io/azure-devops/coverage/ediwang/Edi-GitHub/68)
+![Docker Build and Push](https://github.com/EdiWang/Moonglade/workflows/Docker%20Build%20and%20Push/badge.svg) 
+![.NET Build Linux](https://github.com/EdiWang/Moonglade/workflows/.NET%20Build%20Linux/badge.svg)
 
 The [.NET](https://dotnet.microsoft.com/) blog system of [edi.wang](https://edi.wang) that runs on [**Microsoft Azure**](https://azure.microsoft.com/en-us/). Enabling most common blogging features including posts, comments, categories, archive, tags and pages.
 


### PR DESCRIPTION
To display the correct code coverage, please update the link of that image to the real pipeline ID.

And you need to make sure the pipeline is public accessible (Currently it is not).

And you need to trigger a build via an agent of Windows 2019.

Final example:

![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/aiursoft/Star/5)

Or maybe:

![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/aiursoft/Star/1)