### PR TITLE
Modify the regular expression to support password strings using special characters  

### DIFF
--- a/src/Moonglade.Web/Models/Settings/AccountManageViewModel.cs
+++ b/src/Moonglade.Web/Models/Settings/AccountManageViewModel.cs
@@ -14,7 +14,7 @@ namespace Moonglade.Web.Models.Settings
         [Display(Name = "Password")]
         [MinLength(8, ErrorMessage = "Password must be at least 8 characters"), MaxLength(32)]
         [DataType(DataType.Password)]
-        [RegularExpression(@"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$", ErrorMessage = "Password must be minimum eight characters, at least one letter and one number")]
+        [RegularExpression(@"^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@#$^&*]{8,}$", ErrorMessage = "Password must be minimum eight characters, at least one letter and one number")]
         public string Password { get; set; }
     }
 }

--- a/src/Moonglade.Web/Models/SignInViewModel.cs
+++ b/src/Moonglade.Web/Models/SignInViewModel.cs
@@ -14,7 +14,7 @@ namespace Moonglade.Web.Models
         [Display(Name = "Password")]
         [DataType(DataType.Password)]
         [MinLength(8, ErrorMessage = "Password must be at least 8 characters"), MaxLength(32)]
-        [RegularExpression(@"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$", ErrorMessage = "Password must be minimum eight characters, at least one letter and one number")]
+        [RegularExpression(@"^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@#$^&*]{8,}$", ErrorMessage = "Password must be minimum eight characters, at least one letter and one number")]
         public string Password { get; set; }
     }
 }

--- a/src/Moonglade.Web/Pages/Admin/LocalAccount.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/LocalAccount.cshtml
@@ -166,7 +166,7 @@
                         <input class="form-control" type="password"
                                data-val="true"
                                data-val-regex="Password must be minimum eight characters, at least one letter and one number"
-                               data-val-regex-pattern="^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@#$^&*]{8,}$"
+                               data-val-regex-pattern="^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@@#$^&*]{8,}$"
                                data-val-required="Password is required."
                                data-val-minlength="Password must be a string or array type with a minimum length of '8'."
                                data-val-minlength-min="8"

--- a/src/Moonglade.Web/Pages/Admin/LocalAccount.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/LocalAccount.cshtml
@@ -166,7 +166,7 @@
                         <input class="form-control" type="password"
                                data-val="true"
                                data-val-regex="Password must be minimum eight characters, at least one letter and one number"
-                               data-val-regex-pattern="^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$"
+                               data-val-regex-pattern="^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@#$^&*]{8,}$"
                                data-val-required="Password is required."
                                data-val-minlength="Password must be a string or array type with a minimum length of '8'."
                                data-val-minlength-min="8"


### PR DESCRIPTION
Modify the regular expression to support password strings using special characters, I think we need to allow passwords with special strings.

```
var reg=/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}/
undefined
reg.test('12345678')
false
reg.test('12345678a')
true
reg.test('1234567.8')
false
reg.test('1234567.8a')
false
reg.test('admin12.3.')
false
var reg=/^(?=.*[a-zA-Z])(?=.*[0-9])[A-Za-z0-9._~!@#$^&*]{8,}$/
undefined
reg.test('12345678')
false
reg.test('12345678a')
true
reg.test('1234567.8')
false
reg.test('1234567.8a')
true
reg.test('admin12.3.')
true
```