### PR TITLE
Move the sequence to fix the auto deploy issue.

### DIFF
--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "MoongladeDatabase": "Server=(localdb)\\MSSQLLocalDB;Database=moonglade;Trusted_Connection=True;",
-    "AzureAppConfig": ""
+    "AzureAppConfig": "",
+    "MoongladeDatabase": "Server=(localdb)\\MSSQLLocalDB;Database=moonglade;Trusted_Connection=True;"    
   },
   "Authentication": {
     "Provider": "Local",


### PR DESCRIPTION
This is because the auto-deploy script will replace the line with correct connection string. But missed a comma: `,` in the last.

It's hard for the script to understand JSON.

So the easiest fix is to simply move it.