### PR TITLE
Fix format issue for tinymce. #557

### DIFF
--- a/src/Moonglade.Web/wwwroot/js/app/admin.js
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.js
@@ -186,7 +186,7 @@ var postEditor = {
                 branding: false,
                 block_formats: 'Paragraph=p; Header 2=h2; Header 3=h3; Header 4=h4; Preformatted=pre',
                 fontsize_formats: '8pt 10pt 12pt 14pt 18pt 24pt 36pt',
-                plugins: 'advlist autolink hr autosave link image lists charmap print preview hr anchor pagebreak spellchecker searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table directionality template paste codesample imagetools emoticons',
+                plugins: 'advlist autolink hr autosave link image lists charmap print preview hr anchor pagebreak spellchecker searchreplace wordcount visualblocks visualchars fullscreen insertdatetime media nonbreaking save table directionality template codesample imagetools emoticons formatpainter code',
                 toolbar: 'formatselect | fontsizeselect | bold italic underline strikethrough | forecolor backcolor | removeformat | emoticons link hr image table codesample media | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | code | fullscreen',
                 save_onsavecallback: function () {
                     $('#btn-save').trigger('click');
@@ -197,23 +197,29 @@ var postEditor = {
                 body_class: 'post-content',
                 content_css: '/css/tinymce-bs-bundle.min.css',
                 codesample_languages: [
+                    { text: 'Text', value: 'text' },
                     { text: 'Bash', value: 'bash' },
                     { text: 'C#', value: 'csharp' },
                     { text: 'C', value: 'c' },
                     { text: 'C++', value: 'cpp' },
                     { text: 'CSS', value: 'css' },
+                    { text: 'Dart', value: 'dart' },
                     { text: 'F#', value: 'fsharp' },
+                    { text: 'Go', value: 'go' },
                     { text: 'HTML/XML', value: 'markup' },
                     { text: 'JavaScript', value: 'javascript' },
                     { text: 'Json', value: 'json' },
+                    { text: 'Markdown', value: 'markdown' },
                     { text: 'PowerShell', value: 'powershell' },
                     { text: 'Plain Text', value: 'plaintext' },
                     { text: 'Python', value: 'python' },
                     { text: 'PHP', value: 'php' },
                     { text: 'Ruby', value: 'ruby' },
+                    { text: 'Rust', value: 'rust' },
                     { text: 'SQL', value: 'sql' },
                     { text: 'TypeScript', value: 'typescript' },
-                    { text: 'Visual Basic', value: 'vb' }
+                    { text: 'Visual Basic', value: 'vb' },
+                    { text: 'YAML', value: 'yaml' }
                 ],
                 setup: function (editor) {
                     editor.on('NodeChange', function (e) {

--- a/src/Moonglade.Web/wwwroot/js/app/admin.js
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.js
@@ -197,7 +197,6 @@ var postEditor = {
                 body_class: 'post-content',
                 content_css: '/css/tinymce-bs-bundle.min.css',
                 codesample_languages: [
-                    { text: 'Text', value: 'text' },
                     { text: 'Bash', value: 'bash' },
                     { text: 'C#', value: 'csharp' },
                     { text: 'C', value: 'c' },


### PR DESCRIPTION
Fix #557

This will allow the user to paste formatted text as HTML directly. Like from windows terminal.

![image](https://user-images.githubusercontent.com/19531547/120652387-50938500-c4b2-11eb-9808-4e3f429f80cd.png)
