### PR TITLE
Remove useless project references

### DIFF
--- a/src/Moonglade.Comments/Moonglade.Comments.csproj
+++ b/src/Moonglade.Comments/Moonglade.Comments.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Moonglade.Configuration\Moonglade.Configuration.csproj" />
-    <ProjectReference Include="..\Moonglade.Data\Moonglade.Data.csproj" />
-    <ProjectReference Include="..\Moonglade.Utils\Moonglade.Utils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moonglade.Core/Moonglade.Core.csproj
+++ b/src/Moonglade.Core/Moonglade.Core.csproj
@@ -22,7 +22,5 @@
 
 		<ProjectReference Include="..\Moonglade.Caching\Moonglade.Caching.csproj" />
 		<ProjectReference Include="..\Moonglade.Configuration\Moonglade.Configuration.csproj" />
-		<ProjectReference Include="..\Moonglade.Data\Moonglade.Data.csproj" />
-		<ProjectReference Include="..\Moonglade.Utils\Moonglade.Utils.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Moonglade.Notification.Client/Moonglade.Notification.Client.csproj
+++ b/src/Moonglade.Notification.Client/Moonglade.Notification.Client.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Moonglade.Configuration\Moonglade.Configuration.csproj" />
-    <ProjectReference Include="..\Moonglade.Utils\Moonglade.Utils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moonglade.Syndication/Moonglade.Syndication.csproj
+++ b/src/Moonglade.Syndication/Moonglade.Syndication.csproj
@@ -13,7 +13,5 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Moonglade.Configuration\Moonglade.Configuration.csproj" />
-    <ProjectReference Include="..\Moonglade.Data\Moonglade.Data.csproj" />
-    <ProjectReference Include="..\Moonglade.Utils\Moonglade.Utils.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
```log
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Comments' don't have to reference project 'Moonglade.Data' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Comments' don't have to reference project 'Moonglade.Utils' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Core' don't have to reference project 'Moonglade.Data' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Core' don't have to reference project 'Moonglade.Utils' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Notification.Client' don't have to reference project 'Moonglade.Utils' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Syndication' don't have to reference project 'Moonglade.Data' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Syndication' don't have to reference project 'Moonglade.Utils' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Auth' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Configuration' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Comments' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Core' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
a another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Menus' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Notification.Client' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Pingback' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Syndication' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Theme' don't have to reference package 'MediatR' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Web' don't have to reference package 'Edi.Captcha' because it already has its access via another path!
warn: Aiursoft.NugetNinja.Entry[0]
      The project: 'Moonglade.Web' don't have to reference package 'NUglify' because it already has its access via another path!
```