### PR TITLE
Update install.sh to deploy moonglade with Mysql 

### DIFF
--- a/Deployment/install.sh
+++ b/Deployment/install.sh
@@ -7,6 +7,7 @@ install_Moonglade()
     apt-get update --allow-releaseinfo-change
     apt upgrade -y
     server="$1"
+    db_type="$2"
     
     aiur console/success "Checking..."
     # Valid domain is required
@@ -15,6 +16,13 @@ install_Moonglade()
         echo "IP is correct."
     else
         echo "$server is not your current machine IP!"
+        return 9
+    fi
+
+    # Valid database type mssql(default) and mysql 8.0
+    if [ "$db_type" != "mssql" ] && [ "$db_type" != "mysql" ];
+    then 
+        echo "$db_type is not supported database in this script! try mssql or mysql."
         return 9
     fi
 
@@ -33,7 +41,12 @@ install_Moonglade()
     aiur install/jq
     aiur install/dotnet
     aiur install/caddy
-    aiur install/sql_server $dbPassword
+    if [ "$db_type" == "mssql" ];
+    then
+        aiur install/sql_server $dbPassword
+    else
+        apt install mysql-server -y
+    fi
     #aiur install/node
 
     aiur console/success "Cloning..."
@@ -53,8 +66,17 @@ install_Moonglade()
 
     # Configure appsettings.json
     aiur console/success 'Configuring...'
-    connectionString="Server=tcp:127.0.0.1,1433;Database=Moonglade;uid=sa;Password=$dbPassword;MultipleActiveResultSets=True;"
 
+    # Configure different database type
+    if [ "$db_type" == "mssql" ];
+    then    
+        connectionString="Server=tcp:127.0.0.1,1433;Database=Moonglade;uid=sa;Password=$dbPassword;MultipleActiveResultSets=True;"
+        db_name="SqlServer"
+    else    
+        connectionString="Server=localhost;Port=3306;Database=Moonglade;uid=root;Password=$dbPassword;"
+        db_name="MySql"
+    fi
+    aiur text/edit_json "ConnectionStrings.DatabaseType" $db_name $moonglade_path/appsettings.Production.json
     aiur text/edit_json "ConnectionStrings.MoongladeDatabase" "$connectionString" $moonglade_path/appsettings.Production.json
     aiur text/edit_json "ImageStorage.FileSystemPath" '\/root\/Storage' $moonglade_path/appsettings.Production.json
     aiur text/edit_json "ImageStorage.FileSystemSettings.Path" '\/root\/Storage' $moonglade_path/appsettings.Production.json
@@ -62,8 +84,15 @@ install_Moonglade()
     #npm install web-push -g
 
     # Create database.
-    aiur console/success 'Seeding...'
-    aiur mssql/create_db "Moonglade" $dbPassword
+    if [ "$db_type" == "mssql" ];
+    then
+        aiur console/success 'Seeding...'
+        aiur mssql/create_db "Moonglade" $dbPassword
+    else
+        # Initiate mysql root password and create database Moonglade
+        mysql -uroot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password by '$dbPassword'"
+        mysql -uroot -e "create database Moonglade" -p"$dbPassword"
+    fi
 
     # Register Moonglade service
     aiur console/success "Registering..."
@@ -84,14 +113,24 @@ install_Moonglade()
 
     aiur console/success 'Finlization...'
     # Finish the installation
+    if [ "$db_type" == "mssql" ];
+    then
+        db_port="1433"   
+        db_user="sa"
+        db_data_dir="/var/opt/mssql/"
+    else   
+        db_port="3306"
+        db_user="root"
+        db_data_dir="/var/lib/mysql/"
+    fi
     echo "Successfully installed Moonglade as a service in your machine! Please open https://$server to try it now!"
     echo "Default management user name is "admin" and default password is "admin123". Please open https://$server/admin to try it now!"
-    echo "Successfully installed mssql as a service in your machine! The port is not opened so you can't connect!"
+    echo "Successfully installed $db_type as a service in your machine! The port is not opened so you can't connect!"
     echo "Successfully installed caddy as a service in your machine!"
     sleep 1
-    echo "You can open your database to public via: sudo ufw allow 1433/tcp"
-    echo "You can access your database via: $server:1433 with username: sa and password: $dbPassword"
-    echo "Your database data file is located at: /var/opt/mssql/. Please back up them regularly."
+    echo "You can open your database to public via: sudo ufw allow $db_port/tcp"
+    echo "You can access your database via: $server:$db_port with username: $db_user and password: $dbPassword"
+    echo "Your database data file is located at: $db_data_dir. Please back up them regularly."
     echo "Your web data file is located at: $moonglade_path"
     echo "Your web server config file is located at: /etc/caddy/Caddyfile"
     echo "Strongly maintain your own configuration at $moonglade_path/appsettings.Production.json"

--- a/Deployment/uninstall.sh
+++ b/Deployment/uninstall.sh
@@ -15,6 +15,7 @@ delete_service()
 delete_service "mssql-server.service"
 delete_service "caddy.service"
 delete_service "moonglade.service"
+delete_service "mysql.service"
 
 rm ~/apps/moongladeApp -rvf
 rm ~/Moonglade -rvf
@@ -23,5 +24,6 @@ rm /var/opt/mssql/ -rvf
 
 apt remove caddy -y
 apt remove mssql-server -y
+apt remove mysql-server -y
 
 echo "Successfully uninstalled Kahla on your machine!"


### PR DESCRIPTION
Following wiki installation script to install Moonglade, i can't install successfully. Because my VPS has only 1GB of memory but mssql requires at least 2GB. I try use mysql and follow https://moonglade.blog  to configure appsettings.Development.json and i make it. 

I think that many people's vps have less than or equal to 2GB of memory, so installation script should let users choose mssql or mysql database.
