### PR TITLE
Remove "like" from Statistics

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <Authors>Edi Wang</Authors>
     <Company>edi.wang</Company>
     <Copyright>(C) 2023 edi.wang@outlook.com</Copyright>
-    <AssemblyVersion>12.10.1.0</AssemblyVersion>
-    <FileVersion>12.10.1.0</FileVersion>
-    <Version>12.10.1</Version>
+    <AssemblyVersion>12.11.0.0</AssemblyVersion>
+    <FileVersion>12.11.0.0</FileVersion>
+    <Version>12.11.0-preview</Version>
   </PropertyGroup>
 </Project>

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -61,8 +61,7 @@ public class CreatePostCommandHandler : IRequestHandler<CreatePostCommand, PostE
             InlineCss = request.Payload.InlineCss,
             PostExtension = new()
             {
-                Hits = 0,
-                Likes = 0
+                Hits = 0
             }
         };
 

--- a/src/Moonglade.Core/StatisticFeature/GetStatisticQuery.cs
+++ b/src/Moonglade.Core/StatisticFeature/GetStatisticQuery.cs
@@ -1,16 +1,16 @@
 ﻿namespace Moonglade.Core.StatisticFeature;
 
-public record GetStatisticQuery(Guid PostId) : IRequest<(int Hits, int Likes)>;
+public record GetStatisticQuery(Guid PostId) : IRequest<int>;
 
-public class GetStatisticQueryHandler : IRequestHandler<GetStatisticQuery, (int Hits, int Likes)>
+public class GetStatisticQueryHandler : IRequestHandler<GetStatisticQuery, int>
 {
     private readonly IRepository<PostExtensionEntity> _repo;
 
     public GetStatisticQueryHandler(IRepository<PostExtensionEntity> repo) => _repo = repo;
 
-    public async Task<(int Hits, int Likes)> Handle(GetStatisticQuery request, CancellationToken ct)
+    public async Task<int> Handle(GetStatisticQuery request, CancellationToken ct)
     {
         var pp = await _repo.GetAsync(request.PostId, ct);
-        return (pp.Hits, pp.Likes);
+        return pp.Hits;
     }
 }

--- a/src/Moonglade.Core/StatisticFeature/UpdateStatisticCommand.cs
+++ b/src/Moonglade.Core/StatisticFeature/UpdateStatisticCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Moonglade.Core.StatisticFeature;
 
-public record UpdateStatisticCommand(Guid PostId, bool IsLike) : IRequest;
+public record UpdateStatisticCommand(Guid PostId) : IRequest;
 
 public class UpdateStatisticCommandHandler : IRequestHandler<UpdateStatisticCommand>
 {
@@ -13,16 +13,8 @@ public class UpdateStatisticCommandHandler : IRequestHandler<UpdateStatisticComm
         var pp = await _repo.GetAsync(request.PostId, ct);
         if (pp is null) return;
 
-        if (request.IsLike)
-        {
-            if (pp.Likes >= int.MaxValue) return;
-            pp.Likes += 1;
-        }
-        else
-        {
-            if (pp.Hits >= int.MaxValue) return;
-            pp.Hits += 1;
-        }
+        if (pp.Hits >= int.MaxValue) return;
+        pp.Hits += 1;
 
         await _repo.UpdateAsync(pp, ct);
     }

--- a/src/Moonglade.Data/Entities/PostExtensionEntity.cs
+++ b/src/Moonglade.Data/Entities/PostExtensionEntity.cs
@@ -4,7 +4,6 @@ public class PostExtensionEntity
 {
     public Guid PostId { get; set; }
     public int Hits { get; set; }
-    public int Likes { get; set; }
 
     public virtual PostEntity Post { get; set; }
 }

--- a/src/Moonglade.Data/Exporting/ExportPostDataCommand.cs
+++ b/src/Moonglade.Data/Exporting/ExportPostDataCommand.cs
@@ -24,7 +24,6 @@ public class ExportPostDataCommandHandler : IRequestHandler<ExportPostDataComman
             p.CreateTimeUtc,
             p.CommentEnabled,
             p.PostExtension.Hits,
-            p.PostExtension.Likes,
             p.PubDateUtc,
             p.ContentLanguageCode,
             p.IsDeleted,

--- a/src/Moonglade.Data/Seed.cs
+++ b/src/Moonglade.Data/Seed.cs
@@ -41,8 +41,7 @@ public class Seed
                 IsOriginal = true,
                 PostExtension = new()
                 {
-                    Hits = 1024,
-                    Likes = 512
+                    Hits = 1024
                 },
                 Tags = dbContext.Tag.ToList(),
                 PostCategory = dbContext.PostCategory.ToList()

--- a/src/Moonglade.Web/Controllers/StatisticsController.cs
+++ b/src/Moonglade.Web/Controllers/StatisticsController.cs
@@ -17,8 +17,8 @@ public class StatisticsController : ControllerBase
     [ProducesResponseType(typeof(Tuple<int, int>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get([NotEmpty] Guid postId)
     {
-        var (hits, likes) = await _mediator.Send(new GetStatisticQuery(postId));
-        return Ok(new { Hits = hits, Likes = likes });
+        var hits = await _mediator.Send(new GetStatisticQuery(postId));
+        return Ok(new { Hits = hits });
     }
 
     [HttpPost]
@@ -28,9 +28,9 @@ public class StatisticsController : ControllerBase
     {
         if (DNT) return NoContent();
 
-        await _mediator.Send(new UpdateStatisticCommand(request.PostId, request.IsLike));
+        await _mediator.Send(new UpdateStatisticCommand(request.PostId));
         return NoContent();
     }
 }
 
-public record StatisticsRequest([NotEmpty] Guid PostId, bool IsLike);
+public record StatisticsRequest([NotEmpty] Guid PostId);

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -124,8 +124,7 @@
 
         var pid = document.querySelector('article').dataset.postid;
         viewpost.getStatistics(pid);
-        viewpost.registerRatingButtons(pid);
-        viewpost.postStatistics(pid, false);
+        viewpost.postStatistics(pid);
 
         window.fitImageToDevicePixelRatio = @BlogConfig.ImageSettings.FitImageToDevicePixelRatio.ToString().ToLower();
 

--- a/src/Moonglade.Web/Pages/_PostActions.cshtml
+++ b/src/Moonglade.Web/Pages/_PostActions.cshtml
@@ -1,21 +1,10 @@
 ﻿@model Moonglade.Core.PostFeature.Post
-@{
-    bool isDNT = (bool)Context.Items["DNT"];
-}
 
 <hr />
 <div class="post-slug-actions clearfix mb-2 d-print-none">
     @if (null == ViewBag.IsDraftPreview)
     {
         <div class="float-end">
-            @if (!isDNT)
-            {
-                <a href="javascript:;" class="btn-ratings text-muted d-inline-block me-3">
-                    <i class="bi-heart-fill"></i>
-                    <span class="likehits-num"></span>
-                </a>
-            }
-
             <a href="javascript:;" class="text-muted d-inline-block" data-bs-toggle="modal" data-bs-target="#qrcode-window">
                 <i class="bi-qr-code-scan"></i>
             </a>
@@ -60,7 +49,6 @@
             <div class="modal-header">
                 <div class="modal-title" id="qrcodewindowLabel">@Model.Title</div>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    
                 </button>
             </div>
             <div class="modal-body">

--- a/src/Moonglade.Web/wwwroot/js/app/viewpost.module.js
+++ b/src/Moonglade.Web/wwwroot/js/app/viewpost.module.js
@@ -17,19 +17,13 @@ export function getStatistics(pid) {
         });
 }
 
-export function postStatistics(pid, isLike) {
+export function postStatistics(pid) {
     const req = {
-        postId: pid,
-        isLike: isLike
+        postId: pid
     };
 
     callApi('/api/statistics', 'POST', req,
         (success) => {
-            if (isLike) {
-                let oldVal = parseInt(document.querySelector('.likehits-num').innerText, 10);
-                document.querySelector('.likehits-num').innerHTML = ++oldVal;
-                document.querySelector('.btn-ratings').setAttribute('disabled', 'disabled');
-            }
         });
 }
 
@@ -37,15 +31,6 @@ export function resizeImages() {
     $('.post-content img').removeAttr('height');
     $('.post-content img').removeAttr('width');
     $('.post-content img').addClass('img-fluid img-thumbnail');
-}
-
-export function registerRatingButtons(pid) {
-    $('.btn-ratings').click(function () {
-        if (!hasLiked) {
-            postStatistics(pid, true);
-            hasLiked = true;
-        }
-    });
 }
 
 export function renderCodeHighlighter() {


### PR DESCRIPTION
Reason: Because blog viewers are not required to login, the "like" statistics are not considered to be accurate. 

Migration: Moonglade users need to find third party js plugins and use their own statistics feature.

DB migration:

```tsql
ALTER TABLE PostExtension DROP COLUMN Likes
GO
```