### PR TITLE
Change the --kind parameter in AzureQuickDeploy.ps1

### DIFF
--- a/Deployment/AzureQuickDeploy.ps1
+++ b/Deployment/AzureQuickDeploy.ps1
@@ -177,7 +177,7 @@ $storageAccountCheck = az storage account list --query "[?name=='$storageAccount
 $storageAccountExists = $storageAccountCheck.Length -gt 0
 if (!$storageAccountExists) {
     Write-Host "Creating Storage Account"
-    $echo = az storage account create --name $storageAccountName --resource-group $rsgName --location $regionName --sku Standard_LRS --kind --allow-blob-public-access true StorageV2
+    $echo = az storage account create --name $storageAccountName --resource-group $rsgName --location $regionName --sku Standard_LRS --kind StorageV2 --allow-blob-public-access true
 }
 
 $storageConn = az storage account show-connection-string -g $rsgName -n $storageAccountName | ConvertFrom-Json


### PR DESCRIPTION
Hi @EdiWang ,

When I was trying to deploy this blog system on Azure, it failed.
The root cause was that the --kind parameter is not in the valid format.
I have changed it and successfully deployed a bolg system on Azure.
Please take a look at this fix when u get a chance.

Thanks for the awesome project!