### PR TITLE
Create docker-compose.yml to one click start up.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ROOT_SUPER_EVIL_PASSWORD@1234
+      MYSQL_DATABASE: AppDatabase
+      MYSQL_USER: WebApp
+      MYSQL_PASSWORD: WebApp@Passw0rd
+    ports:
+      - "3306:3306"
+  web:
+    build: .
+    environment:
+      ConnectionStrings__MoongladeDatabase: "Server=db;Database=AppDatabase;Uid=WebApp;Pwd=WebApp@Passw0rd;"
+      ConnectionStrings__DatabaseType: "MySQL"
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
This is a docker-compose file that defines two services, `db` and `web`. 

The `db` service is based on the `mariadb` image and sets environment variables for the root password, database name, user name, and password. It also maps the container's port 3306 to the host's port 3306.

The `web` service builds an image from the current directory (`.`) and sets environment variables for the connection string to the database and the database type. It maps the container's port 80 to the host's port 8080 and depends on the `db` service. It also defines a healthcheck that tests the availability of the web server every 30 seconds.

This docker-compose file can be used to deploy a web application that uses a MySQL database.