### PR TITLE
Remove support for adding an Origin Link for a blog post

### DIFF
--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -41,8 +41,6 @@ public class CreatePostCommandHandler(
             IsDeleted = false,
             IsPublished = request.Payload.IsPublished,
             IsFeatured = request.Payload.Featured,
-            IsOriginal = string.IsNullOrWhiteSpace(request.Payload.OriginLink),
-            OriginLink = string.IsNullOrWhiteSpace(request.Payload.OriginLink) ? null : Helper.SterilizeLink(request.Payload.OriginLink),
             HeroImageUrl = string.IsNullOrWhiteSpace(request.Payload.HeroImageUrl) ? null : Helper.SterilizeLink(request.Payload.HeroImageUrl),
             IsOutdated = request.Payload.IsOutdated
         };

--- a/src/Moonglade.Core/PostFeature/PostEditModel.cs
+++ b/src/Moonglade.Core/PostFeature/PostEditModel.cs
@@ -59,10 +59,6 @@ public class PostEditModel
     [Display(Name = "Change Publish Date")]
     public bool ChangePublishDate { get; set; }
 
-    [Display(Name = "Origin Link")]
-    [DataType(DataType.Url)]
-    public string OriginLink { get; set; }
-
     [Display(Name = "Hero Image")]
     [DataType(DataType.Url)]
     public string HeroImageUrl { get; set; }

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -82,8 +82,6 @@ public class UpdatePostCommandHandler : IRequestHandler<UpdatePostCommand, PostE
         post.IsFeedIncluded = postEditModel.FeedIncluded;
         post.ContentLanguageCode = postEditModel.LanguageCode;
         post.IsFeatured = postEditModel.Featured;
-        post.IsOriginal = string.IsNullOrWhiteSpace(request.Payload.OriginLink);
-        post.OriginLink = string.IsNullOrWhiteSpace(postEditModel.OriginLink) ? null : Helper.SterilizeLink(postEditModel.OriginLink);
         post.HeroImageUrl = string.IsNullOrWhiteSpace(postEditModel.HeroImageUrl) ? null : Helper.SterilizeLink(postEditModel.HeroImageUrl);
         post.IsOutdated = postEditModel.IsOutdated;
 

--- a/src/Moonglade.Data.MySql/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.MySql/Configurations/PostConfiguration.cs
@@ -22,7 +22,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Author).HasMaxLength(64);
         builder.Property(e => e.Slug).HasMaxLength(128);
         builder.Property(e => e.Title).HasMaxLength(128);
-        builder.Property(e => e.OriginLink).HasMaxLength(256);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data.PostgreSql/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.PostgreSql/Configurations/PostConfiguration.cs
@@ -22,7 +22,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Author).HasMaxLength(64);
         builder.Property(e => e.Slug).HasMaxLength(128);
         builder.Property(e => e.Title).HasMaxLength(128);
-        builder.Property(e => e.OriginLink).HasMaxLength(256);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data.SqlServer/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.SqlServer/Configurations/PostConfiguration.cs
@@ -22,7 +22,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Author).HasMaxLength(64);
         builder.Property(e => e.Slug).HasMaxLength(128);
         builder.Property(e => e.Title).HasMaxLength(128);
-        builder.Property(e => e.OriginLink).HasMaxLength(256);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data/Entities/PostEntity.cs
+++ b/src/Moonglade.Data/Entities/PostEntity.cs
@@ -23,9 +23,7 @@ public class PostEntity
     public DateTime? LastModifiedUtc { get; set; }
     public bool IsPublished { get; set; }
     public bool IsDeleted { get; set; }
-    public bool IsOriginal { get; set; }
     public bool IsOutdated { get; set; }
-    public string OriginLink { get; set; }
     public string HeroImageUrl { get; set; }
     public bool IsFeatured { get; set; }
     public int HashCheckSum { get; set; }

--- a/src/Moonglade.Data/Seed.cs
+++ b/src/Moonglade.Data/Seed.cs
@@ -47,7 +47,6 @@ public class Seed
                 LastModifiedUtc = DateTime.UtcNow,
                 PubDateUtc = DateTime.UtcNow,
                 ContentLanguageCode = "en-us",
-                IsOriginal = true,
                 Tags = dbContext.Tag.ToList(),
                 PostCategory = dbContext.PostCategory.ToList()
             };

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -293,10 +293,6 @@
                         </div>
                     </div>
                     <div class="card-body border-top">
-                        <div class="form-floating mb-2">
-                            <textarea asp-for="ViewModel.OriginLink" class="form-control form-control-sm" placeholder="@SharedLocalizer["Origin Link"]"></textarea>
-                            <label for="ViewModel_OriginLink">@SharedLocalizer["Origin Link"]</label>
-                        </div>
                         <div class="form-floating mb-1">
                             <textarea asp-for="ViewModel.HeroImageUrl"
                                       class="form-control form-control-sm"

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
@@ -57,7 +57,6 @@ public class EditPostModel(IMediator mediator, ITimeZoneResolver timeZoneResolve
             LanguageCode = post.ContentLanguageCode,
             Abstract = post.ContentAbstract.Replace("\u00A0\u2026", string.Empty),
             Featured = post.IsFeatured,
-            OriginLink = post.OriginLink,
             HeroImageUrl = post.HeroImageUrl,
             IsOutdated = post.IsOutdated
         };

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -117,11 +117,6 @@
         </h1>
 
         <div class="post-publish-info text-muted mb-2">
-            @if (Model.Post.IsOriginal)
-            {
-                <span class="badge bg-secondary me-2 d-none d-sm-inline">@SharedLocalizer["Original"]</span>
-            }
-
             @if (!string.IsNullOrWhiteSpace(Model.Post.Author))
             {
                 <i class="bi-person d-none d-sm-inline"></i>
@@ -161,14 +156,6 @@
     }
 
     <partial name="_PostActions" model="Model.Post" />
-
-    @if (!string.IsNullOrWhiteSpace(Model.Post.OriginLink))
-    {
-        <a href="@Helper.SterilizeLink(Model.Post.OriginLink)" target="_blank">
-            <i class="bi-link"></i>
-            @SharedLocalizer["Read origin article"]
-        </a>
-    }
 </article>
 
 @if (BlogConfig.ContentSettings.EnableComments)

--- a/src/Moonglade.Web/Pages/PostPreview.cshtml
+++ b/src/Moonglade.Web/Pages/PostPreview.cshtml
@@ -72,14 +72,6 @@
     }
 
     <partial name="_PostActions" model="Model.Post" />
-    
-    @if (!string.IsNullOrWhiteSpace(Model.Post.OriginLink))
-    {
-        <a href="@Helper.SterilizeLink(Model.Post.OriginLink)" target="_blank">
-            <i class="bi-link"></i>
-            @SharedLocalizer["Read origin article"]
-        </a>
-    }
 </article>
 
 <partial name="_LightSwitch" />

--- a/src/Moonglade.Web/Pages/_DublinCoreMetaData.cshtml
+++ b/src/Moonglade.Web/Pages/_DublinCoreMetaData.cshtml
@@ -8,10 +8,6 @@
 <meta name="DC.Format" content="text/html" />
 <meta name="DC.Format.MIME" content="text/html" />
 <meta name="DC.Format.SysReq" content="Internet browser" />
-@if (Model.Post.OriginLink != null)
-{
-    <meta name="DC.Source" content="@Model.Post.OriginLink">
-}
 <meta name="DC.Subject" content="@string.Join(", ", Model.Post.PostCategory.Select(p => p.Category.DisplayName))" />
 <meta name="DC.Subject.Keyword" content="@string.Join(", ", Model.Post.Tags.Select(t => t.NormalizedName))" />
 @if (BlogConfig.GeneralSettings.DcLicenseUrl != null)

--- a/src/Moonglade.Web/Resources/Program.zh-Hans.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hans.resx
@@ -576,12 +576,6 @@
   <data name="Order" xml:space="preserve">
     <value>序号</value>
   </data>
-  <data name="Origin Link" xml:space="preserve">
-    <value>原文链接</value>
-  </data>
-  <data name="Original" xml:space="preserve">
-    <value>原创</value>
-  </data>
   <data name="Owner email" xml:space="preserve">
     <value>博主邮箱</value>
   </data>

--- a/src/Moonglade.Web/Resources/Program.zh-Hant.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hant.resx
@@ -556,12 +556,6 @@
   <data name="Order" xml:space="preserve">
     <value>序號</value>
   </data>
-  <data name="Origin Link" xml:space="preserve">
-    <value>原文網址</value>
-  </data>
-  <data name="Original" xml:space="preserve">
-    <value>原創</value>
-  </data>
   <data name="Owner email" xml:space="preserve">
     <value>博主信箱</value>
   </data>


### PR DESCRIPTION
Nobody uses this feature.

Optional T-SQL migration script

```tsql
ALTER TABLE Post DROP COLUMN IsOriginal
GO

ALTER TABLE Post DROP COLUMN OriginLink
GO
```