### PR TITLE
Scheduled Post Part 1: PostStatus field

### DIFF
--- a/Deployment/mssql-migration.sql
+++ b/Deployment/mssql-migration.sql
@@ -159,3 +159,32 @@ BEGIN
 	)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
 	) ON [PRIMARY]
 END
+
+-- v14.22
+IF NOT EXISTS (
+    SELECT 1 
+    FROM sys.columns 
+    WHERE object_id = OBJECT_ID('dbo.Post') 
+      AND name = 'PostStatus'
+)
+BEGIN
+    ALTER TABLE dbo.Post ADD PostStatus VARCHAR(16) NULL;
+END
+
+IF EXISTS (
+    SELECT 1 
+    FROM sys.columns 
+    WHERE object_id = OBJECT_ID('dbo.Post') 
+      AND name = 'IsPublished'
+)
+BEGIN
+	UPDATE dbo.Post
+	SET PostStatus = 'published'
+	WHERE IsPublished = 1;
+
+	UPDATE dbo.Post
+	SET PostStatus = 'draft'
+	WHERE IsPublished = 0;
+
+    ALTER TABLE dbo.Post DROP COLUMN IsPublished;
+END

--- a/src/Moonglade.Core/PostFeature/CountPostQuery.cs
+++ b/src/Moonglade.Core/PostFeature/CountPostQuery.cs
@@ -32,13 +32,13 @@ public class CountPostQueryHandler(
             case CountType.Category:
                 if (request.CatId == null) throw new ArgumentNullException(nameof(request.CatId));
                 count = await postCatRepo.CountAsync(c => c.CategoryId == request.CatId.Value
-                                                           && c.Post.IsPublished
+                                                           && c.Post.PostStatus == PostStatusConstants.Published
                                                            && !c.Post.IsDeleted, ct);
                 break;
 
             case CountType.Tag:
                 if (request.TagId == null) throw new ArgumentNullException(nameof(request.TagId));
-                count = await postTagRepo.CountAsync(p => p.TagId == request.TagId.Value && p.Post.IsPublished && !p.Post.IsDeleted, ct);
+                count = await postTagRepo.CountAsync(p => p.TagId == request.TagId.Value && p.Post.PostStatus == PostStatusConstants.Published && !p.Post.IsDeleted, ct);
                 break;
 
             case CountType.Featured:

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -49,7 +49,7 @@ public class CreatePostCommandHandler(
             IsFeedIncluded = request.Payload.FeedIncluded,
             PubDateUtc = request.Payload.IsPublished ? utcNow : null,
             IsDeleted = false,
-            IsPublished = request.Payload.IsPublished,
+            PostStatus = request.Payload.IsPublished ? PostStatusConstants.Published : PostStatusConstants.Draft,
             IsFeatured = request.Payload.Featured,
             HeroImageUrl = string.IsNullOrWhiteSpace(request.Payload.HeroImageUrl) ? null : Helper.SterilizeLink(request.Payload.HeroImageUrl),
             IsOutdated = request.Payload.IsOutdated,

--- a/src/Moonglade.Core/PostFeature/ListPostSegmentQuery.cs
+++ b/src/Moonglade.Core/PostFeature/ListPostSegmentQuery.cs
@@ -40,10 +40,10 @@ public class ListPostSegmentQueryHandler(MoongladeRepository<PostEntity> repo) :
         switch (request.PostStatus)
         {
             case PostStatus.Draft:
-                countExp.AndAlso(p => !p.IsPublished && !p.IsDeleted);
+                countExp.AndAlso(p => p.PostStatus == PostStatusConstants.Draft && !p.IsDeleted);
                 break;
             case PostStatus.Published:
-                countExp.AndAlso(p => p.IsPublished && !p.IsDeleted);
+                countExp.AndAlso(p => p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
                 break;
             case PostStatus.Deleted:
                 countExp.AndAlso(p => p.IsDeleted);

--- a/src/Moonglade.Core/PostFeature/PostSegment.cs
+++ b/src/Moonglade.Core/PostFeature/PostSegment.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using Moonglade.Data;
+using System.Linq.Expressions;
 
 namespace Moonglade.Core.PostFeature;
 
@@ -11,7 +12,7 @@ public struct PostSegment
     public DateTime? PubDateUtc { get; set; }
     public DateTime CreateTimeUtc { get; set; }
     public DateTime? LastModifiedUtc { get; set; }
-    public bool IsPublished { get; set; }
+    public string PostStatus { get; set; }
     public bool IsFeatured { get; set; }
     public bool IsDeleted { get; set; }
     public bool IsOutdated { get; set; }
@@ -22,7 +23,7 @@ public struct PostSegment
         Title = p.Title,
         Slug = p.Slug,
         PubDateUtc = p.PubDateUtc,
-        IsPublished = p.IsPublished,
+        PostStatus = p.PostStatus,
         IsFeatured = p.IsFeatured,
         IsDeleted = p.IsDeleted,
         IsOutdated = p.IsOutdated,

--- a/src/Moonglade.Core/PostFeature/PostSegment.cs
+++ b/src/Moonglade.Core/PostFeature/PostSegment.cs
@@ -1,5 +1,4 @@
-﻿using Moonglade.Data;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 namespace Moonglade.Core.PostFeature;
 

--- a/src/Moonglade.Core/PostFeature/SearchPostQuery.cs
+++ b/src/Moonglade.Core/PostFeature/SearchPostQuery.cs
@@ -24,7 +24,7 @@ public class SearchPostQueryHandler(MoongladeRepository<PostEntity> repo) : IReq
     private IQueryable<PostEntity> SearchByKeyword(string keyword)
     {
         var query = repo.AsQueryable()
-            .Where(p => !p.IsDeleted && p.IsPublished).AsNoTracking();
+            .Where(p => !p.IsDeleted && p.PostStatus == PostStatusConstants.Published).AsNoTracking();
 
         var str = Regex.Replace(keyword, @"\s+", " ");
         var rst = str.Split(' ');

--- a/src/Moonglade.Core/PostFeature/UnpublishPostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UnpublishPostCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Edi.CacheAside.InMemory;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
+using Moonglade.Data.Specifications;
 
 namespace Moonglade.Core.PostFeature;
 
@@ -17,7 +18,7 @@ public class UnpublishPostCommandHandler(
         var post = await repo.GetByIdAsync(request.Id, ct);
         if (null == post) return;
 
-        post.IsPublished = false;
+        post.PostStatus = PostStatusConstants.Draft;
         post.PubDateUtc = null;
         post.RouteLink = null;
         post.LastModifiedUtc = DateTime.UtcNow;

--- a/src/Moonglade.Core/PostFeature/UnpublishPostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UnpublishPostCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Edi.CacheAside.InMemory;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
-using Moonglade.Data.Specifications;
 
 namespace Moonglade.Core.PostFeature;
 

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -119,9 +119,9 @@ public class UpdatePostCommandHandler : IRequestHandler<UpdatePostCommand, PostE
                 _configuration.GetValue<EditorChoice>("Post:Editor") == EditorChoice.Markdown)
             : postEditModel.Abstract.Trim();
 
-        if (postEditModel.IsPublished && !post.IsPublished)
+        if (postEditModel.IsPublished && post.PostStatus == PostStatusConstants.Draft)
         {
-            post.IsPublished = true;
+            post.PostStatus = PostStatusConstants.Published;
             post.PubDateUtc = utcNow;
         }
 

--- a/src/Moonglade.Data/Entities/PostEntity.cs
+++ b/src/Moonglade.Data/Entities/PostEntity.cs
@@ -21,12 +21,12 @@ public class PostEntity
     public bool IsFeedIncluded { get; set; }
     public DateTime? PubDateUtc { get; set; }
     public DateTime? LastModifiedUtc { get; set; }
-    public bool IsPublished { get; set; }
     public bool IsDeleted { get; set; }
     public bool IsOutdated { get; set; }
     public string HeroImageUrl { get; set; }
     public bool IsFeatured { get; set; }
     public string RouteLink { get; set; }
+    public string PostStatus { get; set; }
 
     public virtual ICollection<CommentEntity> Comments { get; set; }
     public virtual ICollection<PostCategoryEntity> PostCategory { get; set; }

--- a/src/Moonglade.Data/Exporting/ExportPostDataCommand.cs
+++ b/src/Moonglade.Data/Exporting/ExportPostDataCommand.cs
@@ -22,7 +22,7 @@ public class ExportPostDataCommandHandler(MoongladeRepository<PostEntity> repo) 
             p.ContentLanguageCode,
             p.IsDeleted,
             p.IsFeedIncluded,
-            p.IsPublished,
+            p.PostStatus,
             Categories = p.PostCategory.Select(pc => pc.Category.DisplayName),
             Tags = p.Tags.Select(pt => pt.DisplayName)
         }, ct);

--- a/src/Moonglade.Data/PostStatusConstants.cs
+++ b/src/Moonglade.Data/PostStatusConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Moonglade.Data;
+
+public class PostStatusConstants
+{
+    public const string Draft = "draft";
+    public const string Published = "published";
+}

--- a/src/Moonglade.Data/Seed.cs
+++ b/src/Moonglade.Data/Seed.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moonglade.Data.Entities;
+using Moonglade.Data.Specifications;
 using System.Globalization;
 
 namespace Moonglade.Data;
@@ -38,7 +39,7 @@ public class Seed
                 CommentEnabled = true,
                 CreateTimeUtc = DateTime.UtcNow,
                 ContentAbstract = content,
-                IsPublished = true,
+                PostStatus = PostStatusConstants.Published,
                 IsFeatured = true,
                 IsFeedIncluded = true,
                 LastModifiedUtc = DateTime.UtcNow,

--- a/src/Moonglade.Data/Seed.cs
+++ b/src/Moonglade.Data/Seed.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moonglade.Data.Entities;
-using Moonglade.Data.Specifications;
 using System.Globalization;
 
 namespace Moonglade.Data;

--- a/src/Moonglade.Data/Specifications/FeaturedPostPagingSpec.cs
+++ b/src/Moonglade.Data/Specifications/FeaturedPostPagingSpec.cs
@@ -9,7 +9,7 @@ public sealed class FeaturedPostPagingSpec : Specification<PostEntity>
         Query.Where(p =>
             p.IsFeatured
             && !p.IsDeleted
-            && p.IsPublished);
+            && p.PostStatus == PostStatusConstants.Published);
 
         var startRow = (pageIndex - 1) * pageSize;
         Query.Skip(startRow).Take(pageSize);

--- a/src/Moonglade.Data/Specifications/PostPagingSpec.cs
+++ b/src/Moonglade.Data/Specifications/PostPagingSpec.cs
@@ -6,7 +6,7 @@ public sealed class PostPagingSpec : Specification<PostEntity>
 {
     public PostPagingSpec(int pageSize, int pageIndex, Guid? categoryId = null)
     {
-        Query.Where(p => !p.IsDeleted && p.IsPublished &&
+        Query.Where(p => !p.IsDeleted && p.PostStatus == PostStatusConstants.Published &&
                          (categoryId == null || p.PostCategory.Select(c => c.CategoryId).Contains(categoryId.Value)));
 
         var startRow = (pageIndex - 1) * pageSize;
@@ -25,10 +25,10 @@ public sealed class PostPagingByStatusSpec : Specification<PostEntity>
         switch (postStatus)
         {
             case PostStatus.Draft:
-                Query.Where(p => !p.IsPublished && !p.IsDeleted);
+                Query.Where(p => p.PostStatus == PostStatusConstants.Draft && !p.IsDeleted);
                 break;
             case PostStatus.Published:
-                Query.Where(p => p.IsPublished && !p.IsDeleted);
+                Query.Where(p => p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
                 break;
             case PostStatus.Deleted:
                 Query.Where(p => p.IsDeleted);

--- a/src/Moonglade.Data/Specifications/PostSiteMapSpec.cs
+++ b/src/Moonglade.Data/Specifications/PostSiteMapSpec.cs
@@ -6,7 +6,7 @@ public sealed class PostSiteMapSpec : Specification<PostEntity, PostSiteMapInfo>
 {
     public PostSiteMapSpec()
     {
-        Query.Where(p => p.IsPublished && !p.IsDeleted);
+        Query.Where(p => p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
         Query.Select(p => new PostSiteMapInfo
         {
             RouteLink = p.RouteLink,

--- a/src/Moonglade.Data/Specifications/PostSpec.cs
+++ b/src/Moonglade.Data/Specifications/PostSpec.cs
@@ -33,10 +33,10 @@ public sealed class PostByStatusSpec : Specification<PostEntity>
         switch (status)
         {
             case PostStatus.Draft:
-                Query.Where(p => !p.IsPublished && !p.IsDeleted);
+                Query.Where(p => p.PostStatus == PostStatusConstants.Draft && !p.IsDeleted);
                 break;
             case PostStatus.Published:
-                Query.Where(p => p.IsPublished && !p.IsDeleted);
+                Query.Where(p => p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
                 break;
             case PostStatus.Deleted:
                 Query.Where(p => p.IsDeleted);
@@ -56,7 +56,7 @@ public sealed class FeaturedPostSpec : Specification<PostEntity>
 {
     public FeaturedPostSpec()
     {
-        Query.Where(p => p.IsFeatured && p.IsPublished && !p.IsDeleted);
+        Query.Where(p => p.IsFeatured && p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
     }
 }
 
@@ -66,7 +66,7 @@ public sealed class PostByCatSpec : Specification<PostEntity>
     {
         Query.Where(p =>
                     !p.IsDeleted &&
-                    p.IsPublished &&
+                    p.PostStatus == PostStatusConstants.Published &&
                     p.IsFeedIncluded &&
                     (categoryId == null || p.PostCategory.Any(c => c.CategoryId == categoryId.Value)));
 
@@ -87,7 +87,7 @@ public sealed class PostByYearMonthSpec : Specification<PostEntity>
                          (month == 0 || p.PubDateUtc.Value.Month == month));
 
         // Fix #313: Filter out unpublished posts
-        Query.Where(p => p.IsPublished && !p.IsDeleted);
+        Query.Where(p => p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
 
         Query.OrderByDescending(p => p.PubDateUtc);
         Query.AsNoTracking();
@@ -103,7 +103,7 @@ public sealed class PostByRouteLinkSpec : SingleResultSpecification<PostEntity>
 {
     public PostByRouteLinkSpec(string routeLink)
     {
-        Query.Where(p => p.RouteLink == routeLink && p.IsPublished && !p.IsDeleted);
+        Query.Where(p => p.RouteLink == routeLink && p.PostStatus == PostStatusConstants.Published && !p.IsDeleted);
 
         Query.Include(p => p.Comments)
              .Include(pt => pt.Tags)
@@ -119,7 +119,7 @@ public sealed class PostByDateAndSlugSpec : Specification<PostEntity>
     {
         Query.Where(p =>
                     p.Slug == slug &&
-                    p.IsPublished &&
+                    p.PostStatus == PostStatusConstants.Published &&
                     p.PubDateUtc.Value.Date == date &&
                     !p.IsDeleted);
 
@@ -139,7 +139,7 @@ public sealed class PostByRouteLinkForIdTitleSpec : SingleResultSpecification<Po
     {
         Query.Where(p =>
             p.RouteLink == routeLink &&
-            p.IsPublished &&
+            p.PostStatus == PostStatusConstants.Published &&
             !p.IsDeleted);
 
         Query.Select(p => new ValueTuple<Guid, string>(p.Id, p.Title));

--- a/src/Moonglade.Data/Specifications/PostTagSpec.cs
+++ b/src/Moonglade.Data/Specifications/PostTagSpec.cs
@@ -9,7 +9,7 @@ public sealed class PostTagSpec : Specification<PostTagEntity>
         Query.Where(pt =>
             pt.TagId == tagId
             && !pt.Post.IsDeleted
-            && pt.Post.IsPublished);
+            && pt.Post.PostStatus == PostStatusConstants.Published);
 
         var startRow = (pageIndex - 1) * pageSize;
         Query.Skip(startRow).Take(pageSize);

--- a/src/Moonglade.Web/Controllers/PostController.cs
+++ b/src/Moonglade.Web/Controllers/PostController.cs
@@ -1,5 +1,4 @@
 ﻿using Moonglade.Core.PostFeature;
-using Moonglade.Data.Entities;
 using Moonglade.IndexNow.Client;
 using Moonglade.Pingback;
 using Moonglade.Web.Attributes;

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
@@ -47,7 +47,7 @@ public class EditPostModel(IMediator mediator, ITimeZoneResolver timeZoneResolve
         ViewModel = new()
         {
             PostId = post.Id,
-            IsPublished = post.IsPublished,
+            IsPublished = post.PostStatus == PostStatusConstants.Published,
             EditorContent = post.PostContent,
             Author = post.Author,
             Slug = post.Slug,

--- a/src/Moonglade.Web/Pages/Admin/PostPreview.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/PostPreview.cshtml
@@ -14,7 +14,7 @@
     <meta name="title" content="@Post.Title" />
     <meta name="author" content="@(string.IsNullOrWhiteSpace(Post.Author) ? BlogConfig.GeneralSettings.OwnerName : Post.Author) " />
     <meta name="image-device-dpi" content="@BlogConfig.ImageSettings.FitImageToDevicePixelRatio.ToString().ToLower()" />
-    <meta name="post-is-published" content="@Model.Post.IsPublished.ToString().ToLower()" />
+    <meta name="post-is-published" content="@((Model.Post.PostStatus == PostStatusConstants.Published).ToString().ToLower())" />
 }
 
 @section head {

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -31,7 +31,7 @@
     <meta name="copyright" content="(C) @DateTime.UtcNow.Year @BlogConfig.GeneralSettings.SiteTitle">
     <meta name="author" content="@(string.IsNullOrWhiteSpace(Model.Post.Author) ? BlogConfig.GeneralSettings.OwnerName : Model.Post.Author) " />
     <meta name="image-device-dpi" content="@BlogConfig.ImageSettings.FitImageToDevicePixelRatio.ToString().ToLower()" />
-    <meta name="post-is-published" content="@Model.Post.IsPublished.ToString().ToLower()" />
+    <meta name="post-is-published" content="@((Model.Post.PostStatus == PostStatusConstants.Published).ToString().ToLower())" />
     @if (BlogConfig.GeneralSettings.UseDublinCoreMetaData)
     {
         <partial name="_DublinCoreMetaData" model="Model" />


### PR DESCRIPTION
This pull request introduces a significant refactor to replace the `IsPublished` boolean property with a new `PostStatus` string property across the codebase. This change improves flexibility by allowing more granular post statuses (e.g., "draft" and "published"). The key changes include database schema updates, model adjustments, and updates to business logic, queries, and UI components.

This refactor ensures a more extensible design for managing post statuses while maintaining backward compatibility through migration scripts.