### PR TITLE
Refactor post publication logic and remove IsPublished

### DIFF
--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -47,13 +47,9 @@ public class CreatePostCommandHandler(
             Title = request.Payload.Title.Trim(),
             ContentLanguageCode = request.Payload.LanguageCode,
             IsFeedIncluded = request.Payload.FeedIncluded,
-            PubDateUtc =
-                request.Payload.IsPublished || request.Payload.PostStatus == PostStatusConstants.Published ?
-                utcNow : null,
+            PubDateUtc = request.Payload.PostStatus == PostStatusConstants.Published ? utcNow : null,
             IsDeleted = false,
-            PostStatus =
-                request.Payload.PostStatus ??
-                (request.Payload.IsPublished ? PostStatusConstants.Published : PostStatusConstants.Draft),
+            PostStatus = request.Payload.PostStatus ?? PostStatusConstants.Draft,
             IsFeatured = request.Payload.Featured,
             HeroImageUrl = string.IsNullOrWhiteSpace(request.Payload.HeroImageUrl) ? null : Helper.SterilizeLink(request.Payload.HeroImageUrl),
             IsOutdated = request.Payload.IsOutdated,

--- a/src/Moonglade.Core/PostFeature/PostEditModel.cs
+++ b/src/Moonglade.Core/PostFeature/PostEditModel.cs
@@ -31,9 +31,6 @@ public class PostEditModel
     public string EditorContent { get; set; }
 
     [Required]
-    public bool IsPublished { get; set; }
-
-    [Required]
     public string PostStatus { get; set; }
 
     [Required]

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -119,7 +119,7 @@ public class UpdatePostCommandHandler : IRequestHandler<UpdatePostCommand, PostE
                 _configuration.GetValue<EditorChoice>("Post:Editor") == EditorChoice.Markdown)
             : postEditModel.Abstract.Trim();
 
-        if (postEditModel.IsPublished && post.PostStatus == PostStatusConstants.Draft)
+        if (postEditModel.PostStatus == PostStatusConstants.Published)
         {
             post.PostStatus = PostStatusConstants.Published;
             post.PubDateUtc = utcNow;

--- a/src/Moonglade.Web/Controllers/PostController.cs
+++ b/src/Moonglade.Web/Controllers/PostController.cs
@@ -46,7 +46,7 @@ public class PostController(
                 await mediator.Send(new CreatePostCommand(model)) :
                 await mediator.Send(new UpdatePostCommand(model.PostId, model));
 
-            if (!model.IsPublished || model.PostStatus != PostStatusConstants.Published)
+            if (model.PostStatus != PostStatusConstants.Published)
             {
                 return Ok(new { PostId = postEntity.Id });
             }

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -59,7 +59,6 @@
 <div>
     <form class="post-edit-form" asp-controller="Post" asp-action="CreateOrEdit">
         <input type="hidden" asp-for="ViewModel.PostId" />
-        <input type="hidden" asp-for="ViewModel.IsPublished" />
         <input type="hidden" asp-for="ViewModel.PostStatus" />
         <input type="hidden" asp-for="ViewModel.LastModifiedUtc" />
         <div class="row g-2">
@@ -206,7 +205,7 @@
                     </div>
                 </div>
 
-                @if (Model.ViewModel.IsPublished || Model.ViewModel.PostStatus == PostStatusConstants.Published)
+                @if (Model.ViewModel.PostStatus == PostStatusConstants.Published)
                 {
                     <div class="text-center">
                         <a class="unpublish-link btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#unpublishPostModal">@SharedLocalizer["Unpublish this post"]</a>
@@ -219,7 +218,7 @@
             <button type="submit" class="btn btn-accent ediblogeditor-save" id="btn-save">
                 @SharedLocalizer["Save"]
             </button>
-            @if (!Model.ViewModel.IsPublished || Model.ViewModel.PostStatus != PostStatusConstants.Published)
+            @if (Model.ViewModel.PostStatus != PostStatusConstants.Published)
             {
                 <button type="submit" class="btn btn-outline-accent ediblogeditor-publish" id="btn-publish">
                     @SharedLocalizer["Publish"]

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml.cs
@@ -9,7 +9,6 @@ public class EditPostModel(IMediator mediator, ITimeZoneResolver timeZoneResolve
     public PostEditModel ViewModel { get; set; } = new()
     {
         IsOutdated = false,
-        IsPublished = false,
         PostStatus = PostStatusConstants.Draft,
         Featured = false,
         EnableComment = true,
@@ -48,7 +47,6 @@ public class EditPostModel(IMediator mediator, ITimeZoneResolver timeZoneResolve
         ViewModel = new()
         {
             PostId = post.Id,
-            IsPublished = post.PostStatus == PostStatusConstants.Published,
             PostStatus = post.PostStatus.ToLower().Trim(),
             EditorContent = post.PostContent,
             Author = post.Author,

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editor.module.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editor.module.mjs
@@ -33,7 +33,6 @@ export function initEvents(slugifyTitle) {
     });
 
     document.querySelector('#btn-publish')?.addEventListener('click', function (e) {
-        document.querySelector('input[name="ViewModel.IsPublished"]').value = 'True';
         document.querySelector('input[name="ViewModel.PostStatus"]').value = 'published';
         submitForm(e);
     });
@@ -58,8 +57,7 @@ export function initEvents(slugifyTitle) {
             assignEditorValues(window.mdContentEditor, ".post-content-textarea");
         }
 
-        if (document.querySelector('input[name="ViewModel.IsPublished"]').value === 'True' ||
-            document.querySelector('input[name="ViewModel.PostStatus"]').value === 'published') {
+        if (document.querySelector('input[name="ViewModel.PostStatus"]').value === 'published') {
             const btnPublish = document.querySelector('#btn-publish');
             if (btnPublish) {
                 btnPublish.style.display = 'none';


### PR DESCRIPTION
Updated the logic in `CreatePostCommandHandler` to set `PubDateUtc` only when `PostStatus` is `Published`. Removed the `IsPublished` property from `PostEditModel` and related classes, shifting to a model that relies solely on `PostStatus`. Adjusted the `UpdatePostCommandHandler` and `PostController` to reflect these changes. Modified the `EditPost.cshtml` to remove hidden inputs for `IsPublished` and updated JavaScript in `admin.editor.module.mjs` to simplify checks for post status.