### PR TITLE
LiteBus Migration: Moonglade.FriendLink

### DIFF
--- a/src/Moonglade.Data/Moonglade.Data.csproj
+++ b/src/Moonglade.Data/Moonglade.Data.csproj
@@ -16,6 +16,8 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Ardalis.Specification" Version="9.2.0" />
         <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
+        <PackageReference Include="LiteBus" Version="2.2.1" />
+        <PackageReference Include="LiteBus.Extensions.MicrosoftDependencyInjection" Version="2.2.1" />
         <PackageReference Include="MediatR" Version="12.5.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.18" />
     </ItemGroup>

--- a/src/Moonglade.FriendLink/CreateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/CreateLinkCommand.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using LiteBus.Commands.Abstractions;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
@@ -32,13 +33,13 @@ public class EditLinkRequest : IValidatableObject
     }
 }
 
-public record CreateLinkCommand(EditLinkRequest Payload) : IRequest;
+public record CreateLinkCommand(EditLinkRequest Payload) : ICommand;
 
 public class CreateLinkCommandHandler(
     MoongladeRepository<FriendLinkEntity> repo,
-    ILogger<CreateLinkCommandHandler> logger) : IRequestHandler<CreateLinkCommand>
+    ILogger<CreateLinkCommandHandler> logger) : ICommandHandler<CreateLinkCommand>
 {
-    public async Task Handle(CreateLinkCommand request, CancellationToken ct)
+    public async Task HandleAsync(CreateLinkCommand request, CancellationToken ct)
     {
         var link = new FriendLinkEntity
         {

--- a/src/Moonglade.FriendLink/CreateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/CreateLinkCommand.cs
@@ -1,5 +1,4 @@
 ﻿using LiteBus.Commands.Abstractions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;

--- a/src/Moonglade.FriendLink/DeleteLinkCommand.cs
+++ b/src/Moonglade.FriendLink/DeleteLinkCommand.cs
@@ -1,17 +1,18 @@
-﻿using MediatR;
+﻿using LiteBus.Commands.Abstractions;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
 
 namespace Moonglade.FriendLink;
 
-public record DeleteLinkCommand(Guid Id) : IRequest;
+public record DeleteLinkCommand(Guid Id) : ICommand;
 
 public class DeleteLinkCommandHandler(
     MoongladeRepository<FriendLinkEntity> repo,
-    ILogger<DeleteLinkCommandHandler> logger) : IRequestHandler<DeleteLinkCommand>
+    ILogger<DeleteLinkCommandHandler> logger) : ICommandHandler<DeleteLinkCommand>
 {
-    public async Task Handle(DeleteLinkCommand request, CancellationToken ct)
+    public async Task HandleAsync(DeleteLinkCommand request, CancellationToken ct)
     {
         var link = await repo.GetByIdAsync(request.Id, ct);
         if (null != link)

--- a/src/Moonglade.FriendLink/DeleteLinkCommand.cs
+++ b/src/Moonglade.FriendLink/DeleteLinkCommand.cs
@@ -1,5 +1,4 @@
 ﻿using LiteBus.Commands.Abstractions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;

--- a/src/Moonglade.FriendLink/GetAllLinksQuery.cs
+++ b/src/Moonglade.FriendLink/GetAllLinksQuery.cs
@@ -1,14 +1,15 @@
-﻿using MediatR;
+﻿using LiteBus.Queries.Abstractions;
+using MediatR;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
 
 namespace Moonglade.FriendLink;
 
-public record GetAllLinksQuery : IRequest<List<FriendLinkEntity>>;
+public record GetAllLinksQuery : IQuery<List<FriendLinkEntity>>;
 
-public class GetAllLinksQueryHandler(MoongladeRepository<FriendLinkEntity> repo) : IRequestHandler<GetAllLinksQuery, List<FriendLinkEntity>>
+public class GetAllLinksQueryHandler(MoongladeRepository<FriendLinkEntity> repo) : IQueryHandler<GetAllLinksQuery, List<FriendLinkEntity>>
 {
-    public Task<List<FriendLinkEntity>> Handle(GetAllLinksQuery request, CancellationToken ct)
+    public Task<List<FriendLinkEntity>> HandleAsync(GetAllLinksQuery request, CancellationToken ct)
     {
         return repo.ListAsync(ct);
     }

--- a/src/Moonglade.FriendLink/GetAllLinksQuery.cs
+++ b/src/Moonglade.FriendLink/GetAllLinksQuery.cs
@@ -1,5 +1,4 @@
 ﻿using LiteBus.Queries.Abstractions;
-using MediatR;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
 

--- a/src/Moonglade.FriendLink/GetLinkQuery.cs
+++ b/src/Moonglade.FriendLink/GetLinkQuery.cs
@@ -1,12 +1,13 @@
-﻿using MediatR;
+﻿using LiteBus.Queries.Abstractions;
+using MediatR;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
 
 namespace Moonglade.FriendLink;
 
-public record GetLinkQuery(Guid Id) : IRequest<FriendLinkEntity>;
+public record GetLinkQuery(Guid Id) : IQuery<FriendLinkEntity>;
 
-public class GetLinkQueryHandler(MoongladeRepository<FriendLinkEntity> repo) : IRequestHandler<GetLinkQuery, FriendLinkEntity>
+public class GetLinkQueryHandler(MoongladeRepository<FriendLinkEntity> repo) : IQueryHandler<GetLinkQuery, FriendLinkEntity>
 {
-    public async Task<FriendLinkEntity> Handle(GetLinkQuery request, CancellationToken ct) => await repo.GetByIdAsync(request.Id, ct);
+    public async Task<FriendLinkEntity> HandleAsync(GetLinkQuery request, CancellationToken ct) => await repo.GetByIdAsync(request.Id, ct);
 }

--- a/src/Moonglade.FriendLink/GetLinkQuery.cs
+++ b/src/Moonglade.FriendLink/GetLinkQuery.cs
@@ -1,5 +1,4 @@
 ﻿using LiteBus.Queries.Abstractions;
-using MediatR;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
 

--- a/src/Moonglade.FriendLink/UpdateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/UpdateLinkCommand.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using LiteBus.Commands.Abstractions;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
@@ -6,13 +7,13 @@ using Moonglade.Utils;
 
 namespace Moonglade.FriendLink;
 
-public record UpdateLinkCommand(Guid Id, EditLinkRequest Payload) : IRequest;
+public record UpdateLinkCommand(Guid Id, EditLinkRequest Payload) : ICommand;
 
 public class UpdateLinkCommandHandler(
     MoongladeRepository<FriendLinkEntity> repo,
-    ILogger<UpdateLinkCommandHandler> logger) : IRequestHandler<UpdateLinkCommand>
+    ILogger<UpdateLinkCommandHandler> logger) : ICommandHandler<UpdateLinkCommand>
 {
-    public async Task Handle(UpdateLinkCommand request, CancellationToken ct)
+    public async Task HandleAsync(UpdateLinkCommand request, CancellationToken ct)
     {
         if (!Uri.IsWellFormedUriString(request.Payload.LinkUrl, UriKind.Absolute))
         {

--- a/src/Moonglade.FriendLink/UpdateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/UpdateLinkCommand.cs
@@ -1,5 +1,4 @@
 ﻿using LiteBus.Commands.Abstractions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;

--- a/src/Moonglade.Web/Controllers/FriendLinkController.cs
+++ b/src/Moonglade.Web/Controllers/FriendLinkController.cs
@@ -9,7 +9,9 @@ namespace Moonglade.Web.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
-public class FriendLinkController(IMediator mediator, IQueryMediator queryMediator, ICommandMediator commandMediator) : ControllerBase
+public class FriendLinkController(
+    IQueryMediator queryMediator, ICommandMediator commandMediator
+    ) : ControllerBase
 {
     [HttpPost]
     [ReadonlyMode]
@@ -44,7 +46,7 @@ public class FriendLinkController(IMediator mediator, IQueryMediator queryMediat
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> Update([NotEmpty] Guid id, EditLinkRequest request)
     {
-        await mediator.Send(new UpdateLinkCommand(id, request));
+        await commandMediator.SendAsync(new UpdateLinkCommand(id, request));
         return NoContent();
     }
 

--- a/src/Moonglade.Web/Controllers/FriendLinkController.cs
+++ b/src/Moonglade.Web/Controllers/FriendLinkController.cs
@@ -1,3 +1,4 @@
+using LiteBus.Queries.Abstractions;
 using Moonglade.Data.Entities;
 using Moonglade.FriendLink;
 using Moonglade.Web.Attributes;
@@ -7,7 +8,7 @@ namespace Moonglade.Web.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
-public class FriendLinkController(IMediator mediator) : ControllerBase
+public class FriendLinkController(IMediator mediator, IQueryMediator queryMediator) : ControllerBase
 {
     [HttpPost]
     [ReadonlyMode]
@@ -23,7 +24,7 @@ public class FriendLinkController(IMediator mediator) : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([NotEmpty] Guid id)
     {
-        var link = await mediator.Send(new GetLinkQuery(id));
+        var link = await queryMediator.QueryAsync(new GetLinkQuery(id));
         if (null == link) return NotFound();
 
         return Ok(link);
@@ -33,7 +34,7 @@ public class FriendLinkController(IMediator mediator) : ControllerBase
     [ProducesResponseType<List<FriendLinkEntity>>(StatusCodes.Status200OK)]
     public async Task<IActionResult> List()
     {
-        var list = await mediator.Send(new GetAllLinksQuery());
+        var list = await queryMediator.QueryAsync(new GetAllLinksQuery());
         return Ok(list);
     }
 

--- a/src/Moonglade.Web/Controllers/FriendLinkController.cs
+++ b/src/Moonglade.Web/Controllers/FriendLinkController.cs
@@ -1,3 +1,4 @@
+using LiteBus.Commands.Abstractions;
 using LiteBus.Queries.Abstractions;
 using Moonglade.Data.Entities;
 using Moonglade.FriendLink;
@@ -8,14 +9,14 @@ namespace Moonglade.Web.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/[controller]")]
-public class FriendLinkController(IMediator mediator, IQueryMediator queryMediator) : ControllerBase
+public class FriendLinkController(IMediator mediator, IQueryMediator queryMediator, ICommandMediator commandMediator) : ControllerBase
 {
     [HttpPost]
     [ReadonlyMode]
     [ProducesResponseType(StatusCodes.Status201Created)]
     public async Task<IActionResult> Create(EditLinkRequest request)
     {
-        await mediator.Send(new CreateLinkCommand(request));
+        await commandMediator.SendAsync(new CreateLinkCommand(request));
         return Created(new Uri(request.LinkUrl), request);
     }
 
@@ -52,7 +53,7 @@ public class FriendLinkController(IMediator mediator, IQueryMediator queryMediat
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> Delete([NotEmpty] Guid id)
     {
-        await mediator.Send(new DeleteLinkCommand(id));
+        await commandMediator.SendAsync(new DeleteLinkCommand(id));
         return NoContent();
     }
 }

--- a/src/Moonglade.Web/Handlers/FoafMapHandler.cs
+++ b/src/Moonglade.Web/Handlers/FoafMapHandler.cs
@@ -1,4 +1,5 @@
-﻿using Moonglade.FriendLink;
+﻿using LiteBus.Queries.Abstractions;
+using Moonglade.FriendLink;
 
 namespace Moonglade.Web.Handlers;
 
@@ -7,11 +8,11 @@ public class FoafMapHandler
     public static Delegate Handler => Handle;
 
     public static async Task Handle(
-        HttpContext httpContext, IBlogConfig blogConfig, IMediator mediator, LinkGenerator linkGenerator)
+        HttpContext httpContext, IBlogConfig blogConfig, IMediator mediator, IQueryMediator queryMediator, LinkGenerator linkGenerator)
     {
         var general = blogConfig.GeneralSettings ?? throw new InvalidOperationException("GeneralSettings is null.");
 
-        var friends = await mediator.Send(new GetAllLinksQuery());
+        var friends = await queryMediator.QueryAsync(new GetAllLinksQuery());
         var foafDoc = new FoafDoc
         (
             Name: general.OwnerName,

--- a/src/Moonglade.Web/Moonglade.Web.csproj
+++ b/src/Moonglade.Web/Moonglade.Web.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Edi.Gravatar" Version="1.2.0" />
     <PackageReference Include="Edi.ImageWatermark" Version="2.18.1" />
     <PackageReference Include="Edi.PasswordGenerator" Version="2.1.0" />
+    <PackageReference Include="LiteBus.Extensions.MicrosoftDependencyInjection" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="9.0.7" />
     
     <PackageReference Include="TinyMCE" Version="7.9.1" />

--- a/src/Moonglade.Web/Pages/Admin/FriendLink.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/FriendLink.cshtml
@@ -85,5 +85,5 @@
 
     public List<FriendLinkEntity> Links { get; set; }
 
-    public async Task OnGet() => Links = await Mediator.Send(new GetAllLinksQuery());
+    public async Task OnGet() => Links = await QueryMediator.QueryAsync(new GetAllLinksQuery());
 }

--- a/src/Moonglade.Web/Pages/_ViewImports.cshtml
+++ b/src/Moonglade.Web/Pages/_ViewImports.cshtml
@@ -1,4 +1,5 @@
-﻿@using Microsoft.Extensions.Options
+﻿@using LiteBus.Queries.Abstractions
+@using Microsoft.Extensions.Options
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Microsoft.Extensions.Localization
 
@@ -12,4 +13,5 @@
 @addTagHelper *, Edi.Gravatar
 @inject IBlogConfig BlogConfig
 @inject IMediator Mediator
+@inject IQueryMediator QueryMediator
 @inject IStringLocalizer<Program> SharedLocalizer

--- a/src/Moonglade.Web/ViewComponents/FriendLinkViewComponent.cs
+++ b/src/Moonglade.Web/ViewComponents/FriendLinkViewComponent.cs
@@ -1,12 +1,13 @@
+using LiteBus.Queries.Abstractions;
 using Moonglade.FriendLink;
 
 namespace Moonglade.Web.ViewComponents;
 
-public class FriendLinkViewComponent(IMediator mediator) : ViewComponent
+public class FriendLinkViewComponent(IQueryMediator queryMediator) : ViewComponent
 {
     public async Task<IViewComponentResult> InvokeAsync()
     {
-        var links = await mediator.Send(new GetAllLinksQuery());
+        var links = await queryMediator.QueryAsync(new GetAllLinksQuery());
         return View(links ?? []);
     }
 }


### PR DESCRIPTION
This pull request introduces a migration from `MediatR` to `LiteBus` for handling commands and queries across the Moonglade application. It updates dependencies, refactors command and query handlers, and modifies controllers and other components to use the new `LiteBus` abstractions. The changes aim to improve modularity and provide a more specialized framework for message handling.