### PR TITLE
Add support for configurable head scripts

### DIFF
--- a/src/Moonglade.Configuration/HeadScript.cs
+++ b/src/Moonglade.Configuration/HeadScript.cs
@@ -1,0 +1,15 @@
+﻿namespace Moonglade.Configuration;
+
+public class HeadScriptsOptions
+{
+    public List<HeadScript> HeadScripts { get; set; }
+}
+
+public class HeadScript
+{
+    public string Name { get; set; }
+    public string Url { get; set; }
+    public string Integrity { get; set; }
+    public string CrossOrigin { get; set; }
+    public bool IsAsync { get; set; } = false;
+}

--- a/src/Moonglade.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Moonglade.Web/Pages/Shared/_Layout.cshtml
@@ -28,6 +28,8 @@
     }
 
     bool useServerSideDarkMode = Helper.UseServerSideDarkMode(Configuration, Context);
+
+    var headScripts = Configuration.GetSection("HeadScripts").Get<List<HeadScript>>();
 }
 <!DOCTYPE html>
 <html lang="@langCode" data-bs-theme="@(useServerSideDarkMode ? "dark" : null)">
@@ -95,6 +97,14 @@
     @if (AnalyticsSettings.Value.GoogleAnalytics.Enabled)
     {
         <partial name="_GoogleAnalytics" model="AnalyticsSettings.Value.GoogleAnalytics.GTagId" />
+    }
+
+    @foreach (var script in headScripts)
+    {
+        @if (!string.IsNullOrWhiteSpace(script.Url))
+        {
+            <head-script src="@script.Url" integrity="@script.Integrity" crossorigin="@script.CrossOrigin" async="@script.IsAsync"></head-script>
+        }
     }
 </head>
 <body class="@ViewBag.BodyClass">

--- a/src/Moonglade.Web/TagHelpers/HeadScriptTagHelper.cs
+++ b/src/Moonglade.Web/TagHelpers/HeadScriptTagHelper.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Moonglade.Web.TagHelpers;
+
+[HtmlTargetElement("head-script")]
+public class HeadScriptTagHelper : TagHelper
+{
+    public string Src { get; set; }
+
+    public string Integrity { get; set; }
+
+    public string Crossorigin { get; set; }
+
+    public bool Async { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "script";
+        output.TagMode = TagMode.StartTagAndEndTag;
+
+        if (!string.IsNullOrWhiteSpace(Src))
+        {
+            output.Attributes.SetAttribute("src", Src);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Integrity))
+        {
+            output.Attributes.SetAttribute("integrity", Integrity);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Crossorigin))
+        {
+            output.Attributes.SetAttribute("crossorigin", Crossorigin);
+        }
+
+        if (Async)
+        {
+            output.Attributes.SetAttribute("async", "async");
+        }
+    }
+}

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -87,6 +87,8 @@
     "Enabled": true,
     "TaskIntervalMinutes": 1
   },
+  "HeadScripts": [
+  ],
   "Analytics": {
     "GoogleAnalytics": {
       "Enabled": false,


### PR DESCRIPTION
This pull request introduces functionality for dynamically managing and rendering `<script>` tags in the `<head>` section of the HTML layout via configuration. The most important changes include the addition of a new configuration model, updates to the shared layout to support dynamic scripts, and a custom tag helper for rendering `<script>` tags.

### Configuration and Model Changes:
* Added a new `HeadScriptsOptions` class in `HeadScript.cs` to represent a list of scripts, each defined by properties such as `Name`, `Url`, `Integrity`, `CrossOrigin`, and `IsAsync`. (`src/Moonglade.Configuration/HeadScript.cs`, [src/Moonglade.Configuration/HeadScript.csR1-R15](diffhunk://#diff-04872ad5494bdedc802867d0a28fdf7c79fc66e8673422f028f7c9c70f0a8405R1-R15))
* Updated `appsettings.json` to include a new `HeadScripts` section for defining script configurations. (`src/Moonglade.Web/appsettings.json`, [src/Moonglade.Web/appsettings.jsonR90-R91](diffhunk://#diff-d327768ac3479007ca3ab3b2c33b07edb0c9dbb03aae82ee25edcc86235f1370R90-R91))

### Layout Updates:
* Modified `_Layout.cshtml` to retrieve the `HeadScripts` configuration and iterate through it to render script tags dynamically. (`src/Moonglade.Web/Pages/Shared/_Layout.cshtml`, [[1]](diffhunk://#diff-08241a91076938758f2d023252ab1f001b9c1fc4a0b759af69299b9fd3f57cdcR31-R32) [[2]](diffhunk://#diff-08241a91076938758f2d023252ab1f001b9c1fc4a0b759af69299b9fd3f57cdcR101-R108)

### Tag Helper Implementation:
* Added a `HeadScriptTagHelper` class to simplify rendering `<script>` tags with attributes like `src`, `integrity`, `crossorigin`, and `async`. (`src/Moonglade.Web/TagHelpers/HeadScriptTagHelper.cs`, [src/Moonglade.Web/TagHelpers/HeadScriptTagHelper.csR1-R41](diffhunk://#diff-aa8f0a884492fde239c424b48286adc0d1799471f36d16eb73184e8955fa7cdeR1-R41))