### PR TITLE
Optimize Scheduled Post

### DIFF
--- a/src/Moonglade.Core/PostFeature/GetNextScheduledPostQuery.cs
+++ b/src/Moonglade.Core/PostFeature/GetNextScheduledPostQuery.cs
@@ -1,0 +1,18 @@
+﻿using LiteBus.Queries.Abstractions;
+using Moonglade.Data;
+using Moonglade.Data.Specifications;
+
+namespace Moonglade.Core.PostFeature;
+
+public record GetNextScheduledPostTimeQuery : IQuery<DateTime?>;
+
+public class GetNextScheduledPostTimeQueryHandler(MoongladeRepository<PostEntity> postRepo) :
+    IQueryHandler<GetNextScheduledPostTimeQuery, DateTime?>
+{
+    public async Task<DateTime?> HandleAsync(GetNextScheduledPostTimeQuery request, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var nextPost = await postRepo.FirstOrDefaultAsync(new NextScheduledPostSpec(now), ct);
+        return nextPost?.ScheduledPublishTimeUtc;
+    }
+}

--- a/src/Moonglade.Data/Specifications/ScheduledPostSpec.cs
+++ b/src/Moonglade.Data/Specifications/ScheduledPostSpec.cs
@@ -9,3 +9,12 @@ public sealed class ScheduledPostSpec : Specification<PostEntity>
         Query.Where(p => p.PostStatus == PostStatusConstants.Scheduled && !p.IsDeleted && p.ScheduledPublishTimeUtc <= utcNow);
     }
 }
+
+public class NextScheduledPostSpec : Specification<PostEntity>
+{
+    public NextScheduledPostSpec(DateTime utcNow)
+    {
+        Query.Where(e => e.PostStatus == PostStatusConstants.Scheduled && e.ScheduledPublishTimeUtc > utcNow);
+        Query.OrderBy(e => e.ScheduledPublishTimeUtc);
+    }
+}

--- a/src/Moonglade.Web/BackgroundServices/ScheduledPublishService.cs
+++ b/src/Moonglade.Web/BackgroundServices/ScheduledPublishService.cs
@@ -1,4 +1,5 @@
 ﻿using LiteBus.Commands.Abstractions;
+using LiteBus.Queries.Abstractions;
 using Moonglade.Core.PostFeature;
 
 namespace Moonglade.Web.BackgroundServices;
@@ -39,6 +40,15 @@ public class ScheduledPublishService(
         {
             logger.LogInformation("ScheduledPublishService stopped.");
         }
+    }
+
+    private async Task<DateTime?> GetNextScheduledTimeAsync(CancellationToken cancellationToken)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var queryMediator = scope.ServiceProvider.GetRequiredService<IQueryMediator>();
+
+        var nextScheduledTime = await queryMediator.QueryAsync(new GetNextScheduledPostTimeQuery(), cancellationToken);
+        return nextScheduledTime;
     }
 
     private async Task CheckAndPublishPostsAsync(CancellationToken cancellationToken)

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -84,8 +84,7 @@
     "HeaderName": "Sec-CH-Prefers-Color-Scheme"
   },
   "PostScheduler": {
-    "Enabled": true,
-    "TaskIntervalMinutes": 1
+    "Enabled": true
   },
   "HeadScripts": [
   ],


### PR DESCRIPTION
This pull request introduces a new query-based mechanism to determine the next scheduled post time, refactors the `ScheduledPublishService` to improve scheduling logic, and removes the fixed task interval configuration. The changes enhance flexibility and maintainability by dynamically calculating delays based on scheduled posts.

### New Query for Next Scheduled Post:
* Added `GetNextScheduledPostTimeQuery` and its handler in `src/Moonglade.Core/PostFeature/GetNextScheduledPostQuery.cs` to fetch the next scheduled post time using the repository pattern.
* Introduced `NextScheduledPostSpec` in `src/Moonglade.Data/Specifications/ScheduledPostSpec.cs` to query for the next scheduled post after the current time, ordered by publish time.

### Refactoring of `ScheduledPublishService`:
* Replaced the fixed task interval mechanism with dynamic delay calculation based on the next scheduled post time in `src/Moonglade.Web/BackgroundServices/ScheduledPublishService.cs`.
* Added a fallback delay (`MaxWaitInterval`) for cases where no scheduled posts are found.

### Configuration Simplification:
* Removed the `TaskIntervalMinutes` configuration from `appsettings.json` since the interval is now dynamically calculated.