### PR TITLE
Append cache-busting query to httpService imports

### DIFF
--- a/src/Moonglade.Web/wwwroot/js/app/admin.category.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.category.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { success } from './toastService.mjs'
 
 const editCanvas = new bootstrap.Offcanvas(document.getElementById('editCatCanvas'));

--- a/src/Moonglade.Web/wwwroot/js/app/admin.comments.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.comments.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from '/js/app/utils.module.mjs'
 
 document.querySelectorAll('.btn-delete').forEach(button => {

--- a/src/Moonglade.Web/wwwroot/js/app/admin.draft.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.draft.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editor.module.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editor.module.mjs
@@ -1,4 +1,4 @@
-﻿import { moongladeFetch2 } from './httpService.mjs'
+﻿import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { getPreferredTheme } from './themeService.mjs';
 
 function slugify(text) {

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpage.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpage.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { parseMetaContent } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpost.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpost.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { parseMetaContent, toMagicJson } from './utils.module.mjs'
 import { success, error } from './toastService.mjs'
 import { initEvents, loadTinyMCE, keepAlive, warnDirtyForm } from './admin.editor.module.mjs'

--- a/src/Moonglade.Web/wwwroot/js/app/admin.friendlink.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.friendlink.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { success } from './toastService.mjs'
 
 const editCanvas = new bootstrap.Offcanvas(document.getElementById('editLinkCanvas'));

--- a/src/Moonglade.Web/wwwroot/js/app/admin.localaccount.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.localaccount.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { success } from './toastService.mjs'
 
 const resetPasswordModal = new bootstrap.Modal('#resetPasswordModal');

--- a/src/Moonglade.Web/wwwroot/js/app/admin.mention.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.mention.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from './utils.module.mjs';
 import { success } from './toastService.mjs';
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.post.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.post.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.recyclebin.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.recyclebin.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.scheduled.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.scheduled.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.settings.appearance.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.settings.appearance.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { handleSettingsSubmit } from './admin.settings.mjs';
 import { success } from './toastService.mjs';
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.settings.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.settings.mjs
@@ -1,4 +1,4 @@
-﻿import { moongladeFetch2 } from './httpService.mjs'
+﻿import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { toMagicJson } from './utils.module.mjs'
 import { success } from './toastService.mjs'
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.settings.notification.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.settings.notification.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { handleSettingsSubmit } from './admin.settings.mjs';
 import { success, error } from './toastService.mjs';
 

--- a/src/Moonglade.Web/wwwroot/js/app/admin.tags.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.tags.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs';
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2';
 import { success, error } from './toastService.mjs';
 
 const editCanvas = new bootstrap.Offcanvas(document.getElementById('editTagCanvas'));

--- a/src/Moonglade.Web/wwwroot/js/app/blogpage.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/blogpage.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs'
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { success } from './toastService.mjs';
 
 async function deletePage(pageid) {

--- a/src/Moonglade.Web/wwwroot/js/app/imageuploader.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/imageuploader.mjs
@@ -1,4 +1,4 @@
-﻿import { moongladeFetch2 } from './httpService.mjs'
+﻿import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { success, error } from './toastService.mjs'
 
 export class ImageUploader {

--- a/src/Moonglade.Web/wwwroot/js/app/post.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/post.mjs
@@ -1,4 +1,4 @@
-﻿import { moongladeFetch2 } from './httpService.mjs'
+﻿import { moongladeFetch2 } from './httpService.mjs?v=1426b2'
 import { formatUtcTime, parseMetaContent } from './utils.module.mjs';
 import { resetCaptchaImage, showCaptcha } from './captchaService.mjs';
 import { resizeImages, applyImageZooming } from './post.imageutils.mjs';

--- a/src/Moonglade.Web/wwwroot/js/app/postview.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/postview.mjs
@@ -1,4 +1,4 @@
-import { moongladeFetch2 } from './httpService.mjs';
+import { moongladeFetch2 } from './httpService.mjs?v=1426b2';
 
 const EXPIRATION_DAYS = 30;
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Updated all imports of './httpService.mjs' to include a version query string '?v=1426b2' for cache busting. This ensures clients load the latest version of the module after updates.