### PR TITLE
Add Settings UI to enable or disable the comment section on mobile screens

### DIFF
--- a/src/Moonglade.Configuration/CommentSettings.cs
+++ b/src/Moonglade.Configuration/CommentSettings.cs
@@ -34,6 +34,9 @@ public class CommentSettings : IBlogSettings
     [Display(Name = "Word filter mode")]
     public WordFilterMode WordFilterMode { get; set; }
 
+    [Display(Name = "Show comment section on mobile screens")]
+    public bool EnableCommentSectionOnMobile { get; set; }
+
     [JsonIgnore]
     public static CommentSettings DefaultValue => new()
     {

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -153,7 +153,7 @@
     <partial name="_PostActions" model="Model.Post" />
 </article>
 
-<div class="@(bool.Parse(Configuration["Post:EnableCommentSectionOnMobile"]) ? null : "d-none d-md-block")">
+<div class="@(BlogConfig.CommentSettings.EnableCommentSectionOnMobile ? null : "d-none d-md-block")">
 
 @if (!Helper.GetAppDomainData<bool>("IsReadonlyMode") && BlogConfig.CommentSettings.EnableComments)
 {

--- a/src/Moonglade.Web/Pages/Settings/Comment.cshtml
+++ b/src/Moonglade.Web/Pages/Settings/Comment.cshtml
@@ -19,111 +19,126 @@
                 <h4 class="admin-subtitle fw-bold mb-2">@SharedLocalizer["Comments"]</h4>
 
                 <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                        <div class="col-auto">
-                            <i class="bi-chat-left-dots settings-entry-icon"></i>
-                        </div>
-                        <div class="col">
-                            <label asp-for="@settings.EnableComments" class="form-check-label"></label>
-                        </div>
-                        <div class="col-md-5 text-end">
-                            <div class="form-check form-switch form-control-lg">
-                                <input type="hidden" name="EnableComments" value="false">
-                                <input type="checkbox" name="EnableComments" value="true" class="form-check-input" @(settings.EnableComments ? "checked" : null)>
-                            </div>
+                    <div class="col-auto">
+                        <i class="bi-chat-left-dots settings-entry-icon"></i>
+                    </div>
+                    <div class="col">
+                        <label asp-for="@settings.EnableComments" class="form-check-label"></label>
+                    </div>
+                    <div class="col-md-5 text-end">
+                        <div class="form-check form-switch form-control-lg">
+                            <input type="hidden" name="EnableComments" value="false">
+                            <input type="checkbox" name="EnableComments" value="true" class="form-check-input" @(settings.EnableComments ? "checked" : null)>
                         </div>
                     </div>
+                </div>
 
                 <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                        <div class="col-auto">
-                            <i class="bi-diagram-2 settings-entry-icon"></i>
+                    <div class="col-auto">
+                        <i class="bi-diagram-2 settings-entry-icon"></i>
+                    </div>
+                    <div class="col">
+                        <label asp-for="@settings.CommentProvider" class="me-4"></label>
+                    </div>
+                    <div class="col-md-5 text-end">
+                        <div class="form-check form-check-inline">
+                            @Html.RadioButtonFor(model => settings.CommentProvider, CommentProvider.BuiltIn, new
+                            {
+                                id = CommentProvider.BuiltIn.ToString(),
+                                @class = "form-check-input comment-provider-checkbox"
+                            })
+                            <label class="form-check-label" for="@CommentProvider.BuiltIn">@SharedLocalizer["Built in"]</label>
                         </div>
-                        <div class="col">
-                            <label asp-for="@settings.CommentProvider" class="me-4"></label>
-                        </div>
-                        <div class="col-md-5 text-end">
-                            <div class="form-check form-check-inline">
-                                @Html.RadioButtonFor(model => settings.CommentProvider, CommentProvider.BuiltIn, new
-                                    {
-                                        id = CommentProvider.BuiltIn.ToString(),
-                                        @class = "form-check-input comment-provider-checkbox"
-                                    })
-                                <label class="form-check-label" for="@CommentProvider.BuiltIn">@SharedLocalizer["Built in"]</label>
-                            </div>
-                            <div class="form-check form-check-inline">
-                                @Html.RadioButtonFor(model => settings.CommentProvider, CommentProvider.ThirdParty, new
-                                    {
-                                        id = CommentProvider.ThirdParty.ToString(),
-                                        @class = "form-check-input comment-provider-checkbox"
-                                    })
-                                <label class="form-check-label" for="@CommentProvider.ThirdParty">@SharedLocalizer["Third party"]</label>
-                            </div>
+                        <div class="form-check form-check-inline">
+                            @Html.RadioButtonFor(model => settings.CommentProvider, CommentProvider.ThirdParty, new
+                                                        {
+                                id = CommentProvider.ThirdParty.ToString(),
+                                @class = "form-check-input comment-provider-checkbox"
+                            })
+                            <label class="form-check-label" for="@CommentProvider.ThirdParty">@SharedLocalizer["Third party"]</label>
                         </div>
                     </div>
+                </div>
 
                 <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                        <div class="col-auto">
-                            <i class="settings-entry-icon bi-hourglass-split"></i>
-                        </div>
-                        <div class="col">
-                            <label asp-for="@settings.CloseCommentAfterDays"></label>
-                            <div class="form-text">@SharedLocalizer["Set to 0 to never close comments after any days"]</div>
-                        </div>
-                        <div class="col-4">
-                            <input asp-for="@settings.CloseCommentAfterDays" class="form-control" min="0" max="65536" required />
+                    <div class="col-auto">
+                        <i class="settings-entry-icon bi-hourglass-split"></i>
+                    </div>
+                    <div class="col">
+                        <label asp-for="@settings.CloseCommentAfterDays"></label>
+                        <div class="form-text">@SharedLocalizer["Set to 0 to never close comments after any days"]</div>
+                    </div>
+                    <div class="col-4">
+                        <input asp-for="@settings.CloseCommentAfterDays" class="form-control" min="0" max="65536" required />
+                    </div>
+                </div>
+
+                <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
+                    <div class="col-auto">
+                        <i class="bi-phone settings-entry-icon"></i>
+                    </div>
+                    <div class="col">
+                        <label asp-for="@settings.EnableCommentSectionOnMobile" class="form-check-label"></label>
+                    </div>
+                    <div class="col-md-5 text-end">
+                        <div class="form-check form-switch form-control-lg">
+                            <input type="hidden" name="EnableCommentSectionOnMobile" value="false">
+                            <input type="checkbox" name="EnableCommentSectionOnMobile" value="true" class="form-check-input" @(settings.EnableCommentSectionOnMobile ? "checked" : null)>
                         </div>
                     </div>
+                </div>
 
                 <div class="comment-settings-built-in">
 
-                        <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                            <div class="col-auto">
-                                <i class="bi-sort-numeric-down settings-entry-icon"></i>
-                            </div>
-                            <div class="col">
-                                <label asp-for="@settings.CommentOrder" class="me-4"></label>
-                            </div>
-                            <div class="col-md-5 text-end">
-                                <div class="form-check form-check-inline">
-                                    @Html.RadioButtonFor(model => settings.CommentOrder, CommentOrder.OldToNew, new { id = CommentOrder.OldToNew.ToString(), @class = "form-check-input" })
-                                    <label class="form-check-label" for="@CommentOrder.OldToNew">@SharedLocalizer["Old to new"]</label>
-                                </div>
-                                <div class="form-check form-check-inline">
-                                    @Html.RadioButtonFor(model => settings.CommentOrder, CommentOrder.NewToOld, new { id = CommentOrder.NewToOld.ToString(), @class = "form-check-input" })
-                                    <label class="form-check-label" for="@CommentOrder.NewToOld">@SharedLocalizer["New to old"]</label>
-                                </div>
-                            </div>
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
+                        <div class="col-auto">
+                            <i class="bi-sort-numeric-down settings-entry-icon"></i>
                         </div>
-
-                        <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                            <div class="col-auto">
-                                <i class="bi-person-check settings-entry-icon"></i>
-                            </div>
-                            <div class="col">
-                                <label asp-for="@settings.RequireCommentReview" class="form-check-label"></label>
-                            </div>
-                            <div class="col-md-5 text-end">
-                                <div class="form-check form-switch form-control-lg">
-                                    <input type="hidden" name="RequireCommentReview" value="false">
-                                    <input type="checkbox" name="RequireCommentReview" value="true" class="form-check-input" @(settings.RequireCommentReview ? "checked" : null)>
-                                </div>
-                            </div>
+                        <div class="col">
+                            <label asp-for="@settings.CommentOrder" class="me-4"></label>
                         </div>
-
-                        <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                            <div class="col-auto">
-                                <i class="bi-person-square settings-entry-icon"></i>
+                        <div class="col-md-5 text-end">
+                            <div class="form-check form-check-inline">
+                                @Html.RadioButtonFor(model => settings.CommentOrder, CommentOrder.OldToNew, new { id = CommentOrder.OldToNew.ToString(), @class = "form-check-input" })
+                                <label class="form-check-label" for="@CommentOrder.OldToNew">@SharedLocalizer["Old to new"]</label>
                             </div>
-                            <div class="col">
-                                <label asp-for="@settings.EnableGravatar" class="form-check-label"></label>
-                            </div>
-                            <div class="col-md-5 text-end">
-                                <div class="form-check form-switch form-control-lg">
-                                    <input type="hidden" name="EnableGravatar" value="false">
-                                    <input type="checkbox" name="EnableGravatar" value="true" class="form-check-input" @(settings.EnableGravatar ? "checked" : null)>
-                                </div>
+                            <div class="form-check form-check-inline">
+                                @Html.RadioButtonFor(model => settings.CommentOrder, CommentOrder.NewToOld, new { id = CommentOrder.NewToOld.ToString(), @class = "form-check-input" })
+                                <label class="form-check-label" for="@CommentOrder.NewToOld">@SharedLocalizer["New to old"]</label>
                             </div>
                         </div>
                     </div>
+
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
+                        <div class="col-auto">
+                            <i class="bi-person-check settings-entry-icon"></i>
+                        </div>
+                        <div class="col">
+                            <label asp-for="@settings.RequireCommentReview" class="form-check-label"></label>
+                        </div>
+                        <div class="col-md-5 text-end">
+                            <div class="form-check form-switch form-control-lg">
+                                <input type="hidden" name="RequireCommentReview" value="false">
+                                <input type="checkbox" name="RequireCommentReview" value="true" class="form-check-input" @(settings.RequireCommentReview ? "checked" : null)>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
+                        <div class="col-auto">
+                            <i class="bi-person-square settings-entry-icon"></i>
+                        </div>
+                        <div class="col">
+                            <label asp-for="@settings.EnableGravatar" class="form-check-label"></label>
+                        </div>
+                        <div class="col-md-5 text-end">
+                            <div class="form-check form-switch form-control-lg">
+                                <input type="hidden" name="EnableGravatar" value="false">
+                                <input type="checkbox" name="EnableGravatar" value="true" class="form-check-input" @(settings.EnableGravatar ? "checked" : null)>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <div class="comment-settings-3rd">
                     <div>
@@ -141,57 +156,57 @@
                 <h4 class="admin-subtitle fw-bold mb-2">@SharedLocalizer["Moderation"]</h4>
 
                 @if (!string.IsNullOrWhiteSpace(Configuration["ContentModerator:ApiEndpoint"]))
-                        {
-                            <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
-                                <div class="col-auto">
-                                    <i class="bi-translate settings-entry-icon"></i>
-                                </div>
-                                <div class="col">
-                                    <label asp-for="@settings.EnableWordFilter" class="form-check-label"></label>
-                                </div>
-                                <div class="col-md-5 text-end">
-                                    <div class="form-check form-switch form-control-lg">
-                                        <input type="hidden" name="EnableWordFilter" value="false">
-                                        <input type="checkbox" name="EnableWordFilter" value="true" class="form-check-input" @(settings.EnableWordFilter ? "checked" : null)>
-                                    </div>
-                                </div>
+                {
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-1">
+                        <div class="col-auto">
+                            <i class="bi-translate settings-entry-icon"></i>
+                        </div>
+                        <div class="col">
+                            <label asp-for="@settings.EnableWordFilter" class="form-check-label"></label>
+                        </div>
+                        <div class="col-md-5 text-end">
+                            <div class="form-check form-switch form-control-lg">
+                                <input type="hidden" name="EnableWordFilter" value="false">
+                                <input type="checkbox" name="EnableWordFilter" value="true" class="form-check-input" @(settings.EnableWordFilter ? "checked" : null)>
                             </div>
+                        </div>
+                    </div>
 
-                            <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-2">
-                                <div class="col-auto">
-                                    <i class="bi-check2-circle settings-entry-icon"></i>
-                                </div>
-                                <div class="col">
-                                    <label asp-for="@settings.WordFilterMode" class="me-4"></label>
-                                    <div class="form-text">@SharedLocalizer["Blocked words will be masked as * in content."]</div>
-                                </div>
-                                <div class="col-md-5 text-end">
-                                    <div class="form-check form-check-inline">
-                                        @Html.RadioButtonFor(model => settings.WordFilterMode, WordFilterMode.Mask, new { id = WordFilterMode.Mask.ToString(), @class = "form-check-input" })
-                                        <label class="form-check-label" for="@WordFilterMode.Mask">@SharedLocalizer["Mask Word"]</label>
-                                    </div>
-                                    <div class="form-check form-check-inline">
-                                        @Html.RadioButtonFor(model => settings.WordFilterMode, WordFilterMode.Block, new { id = WordFilterMode.Block.ToString(), @class = "form-check-input" })
-                                        <label class="form-check-label" for="@WordFilterMode.Block">@SharedLocalizer["Block Comment"]</label>
-                                    </div>
-                                </div>
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-2">
+                        <div class="col-auto">
+                            <i class="bi-check2-circle settings-entry-icon"></i>
+                        </div>
+                        <div class="col">
+                            <label asp-for="@settings.WordFilterMode" class="me-4"></label>
+                            <div class="form-text">@SharedLocalizer["Blocked words will be masked as * in content."]</div>
+                        </div>
+                        <div class="col-md-5 text-end">
+                            <div class="form-check form-check-inline">
+                                @Html.RadioButtonFor(model => settings.WordFilterMode, WordFilterMode.Mask, new { id = WordFilterMode.Mask.ToString(), @class = "form-check-input" })
+                                <label class="form-check-label" for="@WordFilterMode.Mask">@SharedLocalizer["Mask Word"]</label>
                             </div>
-                        }
-                        else
-                        {
-                            <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-2">
-                                <div class="col-auto">
-                                    <i class="bi-translate settings-entry-icon"></i>
-                                </div>
-                                <div class="col">
-                                    <label asp-for="@settings.EnableWordFilter" class="form-check-label"></label>
-                                    <div class="form-text">Please follow <a href="https://github.com/EdiWang/Moonglade.ContentSecurity" target="_blank">instruction</a> to setup content security API</div>
-                                </div>
-                                <div class="col-md-5 text-end">
-                                    <a class="btn btn-sm btn-outline-accent" href="https://github.com/EdiWang/Moonglade.ContentSecurity" target="_blank">Setup</a>
-                                </div>
+                            <div class="form-check form-check-inline">
+                                @Html.RadioButtonFor(model => settings.WordFilterMode, WordFilterMode.Block, new { id = WordFilterMode.Block.ToString(), @class = "form-check-input" })
+                                <label class="form-check-label" for="@WordFilterMode.Block">@SharedLocalizer["Block Comment"]</label>
                             </div>
-                        }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="settings-entry row align-items-center py-3 px-2 rounded-3 border mb-2">
+                        <div class="col-auto">
+                            <i class="bi-translate settings-entry-icon"></i>
+                        </div>
+                        <div class="col">
+                            <label asp-for="@settings.EnableWordFilter" class="form-check-label"></label>
+                            <div class="form-text">Please follow <a href="https://github.com/EdiWang/Moonglade.ContentSecurity" target="_blank">instruction</a> to setup content security API</div>
+                        </div>
+                        <div class="col-md-5 text-end">
+                            <a class="btn btn-sm btn-outline-accent" href="https://github.com/EdiWang/Moonglade.ContentSecurity" target="_blank">Setup</a>
+                        </div>
+                    </div>
+                }
             </div>
         </div>
     </div>

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -60,8 +60,7 @@
     "Editor": "HTML",
     "EnableViewCount": true,
     "MaximumPageNumbersToDisplay": 5,
-    "CacheMinutes": 20,
-    "EnableCommentSectionOnMobile": false
+    "CacheMinutes": 20
   },
   "Widget": {
     "TagsCacheMinutes": 30,


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable the comment section on mobile screens via a configuration setting. The changes involve updates to the settings model, UI, and configuration file to support this feature.

### New Feature: Mobile Comment Section Toggle

* Added a new property `EnableCommentSectionOnMobile` in the `CommentSettings` class to control the visibility of the comment section on mobile screens. (`src/Moonglade.Configuration/CommentSettings.cs`)
* Updated the `Post.cshtml` file to use the new `EnableCommentSectionOnMobile` property from `CommentSettings` for conditional rendering of the comment section on mobile devices. (`src/Moonglade.Web/Pages/Post.cshtml`)
* Added a new UI element in the `Comment.cshtml` settings page to allow users to toggle the `EnableCommentSectionOnMobile` setting via a switch. (`src/Moonglade.Web/Pages/Settings/Comment.cshtml`)

### Configuration Updates

* Removed the `EnableCommentSectionOnMobile` setting from `appsettings.json` to centralize its management in the `CommentSettings` class. (`src/Moonglade.Web/appsettings.json`)