### PR TITLE
Remove EF Core Lazy Loading

### DIFF
--- a/src/Moonglade.Data.MySql/ServiceCollectionExtensions.cs
+++ b/src/Moonglade.Data.MySql/ServiceCollectionExtensions.cs
@@ -11,12 +11,12 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped(typeof(MoongladeRepository<>), typeof(MySqlDbContextRepository<>));
 
-        services.AddDbContext<BlogDbContext, MySqlBlogDbContext>(optionsAction => optionsAction.UseLazyLoadingProxies()
-            .UseMySQL(connectionString, builder =>
-            {
-                builder.EnableRetryOnFailure(3, TimeSpan.FromSeconds(30), null);
-            })
-            .EnableDetailedErrors());
+        services.AddDbContext<BlogDbContext, MySqlBlogDbContext>(options => options
+                .UseMySQL(connectionString, builder =>
+                {
+                    builder.EnableRetryOnFailure(3, TimeSpan.FromSeconds(30), null);
+                })
+                .EnableDetailedErrors());
 
         return services;
     }

--- a/src/Moonglade.Data.PostgreSql/ServiceCollectionExtensions.cs
+++ b/src/Moonglade.Data.PostgreSql/ServiceCollectionExtensions.cs
@@ -11,8 +11,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped(typeof(MoongladeRepository<>), typeof(PostgreSqlDbContextRepository<>));
 
         AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
-        services.AddDbContext<BlogDbContext, PostgreSqlBlogDbContext>(optionsAction => optionsAction
-            .UseLazyLoadingProxies()
+        services.AddDbContext<BlogDbContext, PostgreSqlBlogDbContext>(options => options
             .EnableDetailedErrors()
             .UseNpgsql(connectionString, options =>
             {

--- a/src/Moonglade.Data.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/Moonglade.Data.SqlServer/ServiceCollectionExtensions.cs
@@ -11,8 +11,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped(typeof(MoongladeRepository<>), typeof(SqlServerDbContextRepository<>));
 
-        services.AddDbContext<BlogDbContext, SqlServerBlogDbContext>(options =>
-            options.UseLazyLoadingProxies()
+        services.AddDbContext<BlogDbContext, SqlServerBlogDbContext>(options => options
                 .UseSqlServer(connectionString, builder =>
                 {
                     builder.EnableRetryOnFailure(3, TimeSpan.FromSeconds(30), null);

--- a/src/Moonglade.Data/Entities/CategoryEntity.cs
+++ b/src/Moonglade.Data/Entities/CategoryEntity.cs
@@ -16,7 +16,7 @@ public class CategoryEntity
     public string Note { get; set; }
 
     [JsonIgnore]
-    public virtual ICollection<PostCategoryEntity> PostCategory { get; set; }
+    public ICollection<PostCategoryEntity> PostCategory { get; set; }
 }
 
 internal class CategoryConfiguration : IEntityTypeConfiguration<CategoryEntity>

--- a/src/Moonglade.Data/Entities/CommentEntity.cs
+++ b/src/Moonglade.Data/Entities/CommentEntity.cs
@@ -16,6 +16,6 @@ public class CommentEntity
     public Guid PostId { get; set; }
     public bool IsApproved { get; set; }
 
-    public virtual PostEntity Post { get; set; }
-    public virtual ICollection<CommentReplyEntity> Replies { get; set; }
+    public PostEntity Post { get; set; }
+    public ICollection<CommentReplyEntity> Replies { get; set; }
 }

--- a/src/Moonglade.Data/Entities/CommentReplyEntity.cs
+++ b/src/Moonglade.Data/Entities/CommentReplyEntity.cs
@@ -7,5 +7,5 @@ public class CommentReplyEntity
     public DateTime CreateTimeUtc { get; set; }
     public Guid? CommentId { get; set; }
 
-    public virtual CommentEntity Comment { get; set; }
+    public CommentEntity Comment { get; set; }
 }

--- a/src/Moonglade.Data/Entities/PostCategoryEntity.cs
+++ b/src/Moonglade.Data/Entities/PostCategoryEntity.cs
@@ -8,8 +8,8 @@ public class PostCategoryEntity
     public Guid CategoryId { get; set; }
 
     [JsonIgnore]
-    public virtual CategoryEntity Category { get; set; }
+    public CategoryEntity Category { get; set; }
 
     [JsonIgnore]
-    public virtual PostEntity Post { get; set; }
+    public PostEntity Post { get; set; }
 }

--- a/src/Moonglade.Data/Entities/PostEntity.cs
+++ b/src/Moonglade.Data/Entities/PostEntity.cs
@@ -29,7 +29,7 @@ public class PostEntity
     public string RouteLink { get; set; }
     public string PostStatus { get; set; }
 
-    public virtual ICollection<CommentEntity> Comments { get; set; }
-    public virtual ICollection<PostCategoryEntity> PostCategory { get; set; }
-    public virtual ICollection<TagEntity> Tags { get; set; }
+    public ICollection<CommentEntity> Comments { get; set; }
+    public ICollection<PostCategoryEntity> PostCategory { get; set; }
+    public ICollection<TagEntity> Tags { get; set; }
 }

--- a/src/Moonglade.Data/Entities/PostTagEntity.cs
+++ b/src/Moonglade.Data/Entities/PostTagEntity.cs
@@ -5,6 +5,6 @@ public class PostTagEntity
     public Guid PostId { get; set; }
     public int TagId { get; set; }
 
-    public virtual PostEntity Post { get; set; }
-    public virtual TagEntity Tag { get; set; }
+    public PostEntity Post { get; set; }
+    public TagEntity Tag { get; set; }
 }

--- a/src/Moonglade.Data/Entities/TagEntity.cs
+++ b/src/Moonglade.Data/Entities/TagEntity.cs
@@ -19,5 +19,5 @@ public class TagEntity
     public string NormalizedName { get; set; }
 
     [JsonIgnore]
-    public virtual ICollection<PostEntity> Posts { get; set; }
+    public ICollection<PostEntity> Posts { get; set; }
 }

--- a/src/Moonglade.Data/Moonglade.Data.csproj
+++ b/src/Moonglade.Data/Moonglade.Data.csproj
@@ -18,7 +18,6 @@
         <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
         <PackageReference Include="LiteBus" Version="3.1.0" />
         <PackageReference Include="LiteBus.Extensions.MicrosoftDependencyInjection" Version="3.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.8" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
This pull request makes several changes to the data access layer, primarily aimed at removing the use of EF Core's lazy loading proxies and simplifying entity relationships. The changes affect the configuration of database contexts for MySQL, PostgreSQL, and SQL Server, as well as the entity classes themselves. The most important changes are summarized below:

### Removal of Lazy Loading Proxies

* Removed the use of `.UseLazyLoadingProxies()` from the `AddDbContext` configuration in `ServiceCollectionExtensions.cs` for MySQL, PostgreSQL, and SQL Server, which disables EF Core's lazy loading feature for navigation properties. [[1]](diffhunk://#diff-1e542075d347f8f445a71c255db0cd64d7028d38bbb7c26462850d20fcd598deL14-R14) [[2]](diffhunk://#diff-dfe7843d844b5b5edc4d00d7a3a5d997adb55dd92a7161d9fde8fbdfeb1e5ef7L14-R14) [[3]](diffhunk://#diff-90036e3842973ef42c63413369616f0d38e0d6d457aab26265cf834bb7c4024fL14-R14)
* Removed the `Microsoft.EntityFrameworkCore.Proxies` NuGet package from the project dependencies, as it is no longer needed without lazy loading proxies.

### Entity Relationship Simplification

* Removed the `virtual` keyword from all navigation properties in entity classes (such as `CategoryEntity`, `CommentEntity`, `CommentReplyEntity`, `PostCategoryEntity`, `PostEntity`, `PostTagEntity`, and `TagEntity`), making them plain properties and thus not eligible for proxy-based lazy loading. [[1]](diffhunk://#diff-cc332800bde05b10ffffc5e668a719b4376f61490f770d68da4bb83f51ec1568L19-R19) [[2]](diffhunk://#diff-8041c0a98c5f7b94c72bb060354a1f420f06e1f9aff2664cbb391fc5e4176f14L19-R20) [[3]](diffhunk://#diff-f34c8c64b98413fe83518ab197e75dd502eec6bc7d4560f71aa8ab953a5a9930L10-R10) [[4]](diffhunk://#diff-00d63b072d04ff06ab070f5e204bcff6cbbc820e7d3c3309a18fa172e4a3b69cL11-R14) [[5]](diffhunk://#diff-b85cab00cd174b328263cbe1138ec5d84351ddaf1b68431f7049f6a95a2fa6d3L32-R34) [[6]](diffhunk://#diff-fa125ba0dc0f31cf29579beeb50b32a7aaed6bbc814f51bdbc7cb76e2c7ef055L8-R9) [[7]](diffhunk://#diff-19ae35ec75858e843e16cd47f27f6a614db6e96e35081a746ef591755b9a0405L22-R22)