### PR TITLE
Moonglade.Utils refactors and Unit Tests

### DIFF
--- a/src/Moonglade.Auth/ValidateLoginCommand.cs
+++ b/src/Moonglade.Auth/ValidateLoginCommand.cs
@@ -19,7 +19,7 @@ public class ValidateLoginCommandHandler(
         if (account is null) return Task.FromResult(false);
         if (account.Username != request.Username) return Task.FromResult(false);
 
-        var valid = account.PasswordHash == Helper.HashPassword(request.InputPassword.Trim(), account.PasswordSalt);
+        var valid = account.PasswordHash == SecurityHelper.HashPassword(request.InputPassword.Trim(), account.PasswordSalt);
 
         if (!valid)
         {

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -55,7 +55,7 @@ public class CreatePostCommandHandler(
             IsDeleted = false,
             PostStatus = request.Payload.PostStatus ?? PostStatusConstants.Draft,
             IsFeatured = request.Payload.Featured,
-            HeroImageUrl = string.IsNullOrWhiteSpace(request.Payload.HeroImageUrl) ? null : Helper.SterilizeLink(request.Payload.HeroImageUrl),
+            HeroImageUrl = string.IsNullOrWhiteSpace(request.Payload.HeroImageUrl) ? null : SecurityHelper.SterilizeLink(request.Payload.HeroImageUrl),
             IsOutdated = request.Payload.IsOutdated,
         };
 

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -59,7 +59,7 @@ public class CreatePostCommandHandler(
             IsOutdated = request.Payload.IsOutdated,
         };
 
-        post.RouteLink = Helper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), request.Payload.Slug);
+        post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), request.Payload.Slug);
 
         await CheckSlugConflict(post, ct);
 

--- a/src/Moonglade.Core/PostFeature/PublishPostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/PublishPostCommand.cs
@@ -25,7 +25,7 @@ public class PublishPostCommandHandler(
         post.PubDateUtc = utcNow;
         post.ScheduledPublishTimeUtc = null;
         post.LastModifiedUtc = utcNow;
-        post.RouteLink = Helper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), post.Slug);
+        post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), post.Slug);
 
         await repo.UpdateAsync(post, ct);
 

--- a/src/Moonglade.Core/PostFeature/PublishScheduledPostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/PublishScheduledPostCommand.cs
@@ -25,7 +25,7 @@ public class PublishScheduledPostCommandHandler(MoongladeRepository<PostEntity> 
             post.PostStatus = PostStatusConstants.Published;
             post.PubDateUtc = now;
             post.ScheduledPublishTimeUtc = null;
-            post.RouteLink = Helper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), post.Slug);
+            post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), post.Slug);
 
             await postRepo.UpdateAsync(post, ct);
 

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -124,7 +124,7 @@ public class UpdatePostCommandHandler(
         post.IsFeatured = postEditModel.Featured;
         post.HeroImageUrl = string.IsNullOrWhiteSpace(postEditModel.HeroImageUrl) ? null : SecurityHelper.SterilizeLink(postEditModel.HeroImageUrl);
         post.IsOutdated = postEditModel.IsOutdated;
-        post.RouteLink = Helper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), postEditModel.Slug);
+        post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), postEditModel.Slug);
     }
 
     private static void UpdateCats(PostEntity post, Guid[] catIds, CancellationToken ct)

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -122,7 +122,7 @@ public class UpdatePostCommandHandler(
         post.IsFeedIncluded = postEditModel.FeedIncluded;
         post.ContentLanguageCode = postEditModel.LanguageCode;
         post.IsFeatured = postEditModel.Featured;
-        post.HeroImageUrl = string.IsNullOrWhiteSpace(postEditModel.HeroImageUrl) ? null : Helper.SterilizeLink(postEditModel.HeroImageUrl);
+        post.HeroImageUrl = string.IsNullOrWhiteSpace(postEditModel.HeroImageUrl) ? null : SecurityHelper.SterilizeLink(postEditModel.HeroImageUrl);
         post.IsOutdated = postEditModel.IsOutdated;
         post.RouteLink = Helper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), postEditModel.Slug);
     }

--- a/src/Moonglade.FriendLink/CreateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/CreateLinkCommand.cs
@@ -43,7 +43,7 @@ public class CreateLinkCommandHandler(
         var link = new FriendLinkEntity
         {
             Id = Guid.NewGuid(),
-            LinkUrl = Helper.SterilizeLink(request.Payload.LinkUrl),
+            LinkUrl = SecurityHelper.SterilizeLink(request.Payload.LinkUrl),
             Title = request.Payload.Title,
             Rank = request.Payload.Rank
         };

--- a/src/Moonglade.FriendLink/UpdateLinkCommand.cs
+++ b/src/Moonglade.FriendLink/UpdateLinkCommand.cs
@@ -23,7 +23,7 @@ public class UpdateLinkCommandHandler(
         if (link is not null)
         {
             link.Title = request.Payload.Title;
-            link.LinkUrl = Helper.SterilizeLink(request.Payload.LinkUrl);
+            link.LinkUrl = SecurityHelper.SterilizeLink(request.Payload.LinkUrl);
             link.Rank = request.Payload.Rank;
 
             await repo.UpdateAsync(link, ct);

--- a/src/Moonglade.ImageStorage/GuidFileNameGenerator.cs
+++ b/src/Moonglade.ImageStorage/GuidFileNameGenerator.cs
@@ -12,7 +12,7 @@ public class GuidFileNameGenerator(Guid id) : IFileNameGenerator
 
         var ext = Path.GetExtension(fileName);
         var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
-        
+
         if (string.IsNullOrEmpty(ext))
         {
             throw new ArgumentException("File must have an extension.", nameof(fileName));

--- a/src/Moonglade.ImageStorage/Providers/AzureBlobImageStorage.cs
+++ b/src/Moonglade.ImageStorage/Providers/AzureBlobImageStorage.cs
@@ -110,7 +110,7 @@ public class AzureBlobImageStorage : IBlogImageStorage
         {
             _logger.LogInformation("Deleting blob '{FileName}' from Azure Blob Storage.", fileName);
             var response = await _container.DeleteBlobIfExistsAsync(fileName).ConfigureAwait(false);
-            
+
             if (response.Value)
             {
                 _logger.LogInformation("Successfully deleted blob '{FileName}' from Azure Blob Storage.", fileName);

--- a/src/Moonglade.Pingback/PingbackSender.cs
+++ b/src/Moonglade.Pingback/PingbackSender.cs
@@ -25,7 +25,7 @@ public class PingbackSender(HttpClient httpClient,
             {
                 logger.LogInformation("URL is detected in post content, trying to send ping requests.");
 
-                foreach (var url in Helper.GetUrlsFromContent(postContent))
+                foreach (var url in UrlHelper.GetUrlsFromContent(postContent))
                 {
                     if (url.IsLocalhostUrl())
                     {

--- a/src/Moonglade.Pingback/ReceivePingCommand.cs
+++ b/src/Moonglade.Pingback/ReceivePingCommand.cs
@@ -55,7 +55,7 @@ public class ReceivePingCommandHandler(
                 return PingbackResponse.SpamDetectedFakeNotFound;
             }
 
-            var routeLink = Helper.GetRouteLinkFromUrl(pingRequest.TargetUrl);
+            var routeLink = UrlHelper.GetRouteLinkFromUrl(pingRequest.TargetUrl);
             var spec = new PostByRouteLinkForIdTitleSpec(routeLink);
             var (id, title) = await postRepo.FirstOrDefaultAsync(spec, ct);
             if (id == Guid.Empty)

--- a/src/Moonglade.Utils.Tests/BlogTagHelperTests.cs
+++ b/src/Moonglade.Utils.Tests/BlogTagHelperTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-
-namespace Moonglade.Utils.Tests;
+﻿namespace Moonglade.Utils.Tests;
 
 public class BlogTagHelperTests
 {

--- a/src/Moonglade.Utils.Tests/BlogTagHelperTests.cs
+++ b/src/Moonglade.Utils.Tests/BlogTagHelperTests.cs
@@ -1,0 +1,515 @@
+﻿using System.Text;
+
+namespace Moonglade.Utils.Tests;
+
+public class BlogTagHelperTests
+{
+    #region TagNormalizationDictionary Tests
+
+    [Fact]
+    public void TagNormalizationDictionary_ContainsExpectedMappings()
+    {
+        // Act
+        var dictionary = BlogTagHelper.TagNormalizationDictionary;
+
+        // Assert
+        Assert.NotNull(dictionary);
+        Assert.Equal(4, dictionary.Count);
+        Assert.Equal("-", dictionary["."]);
+        Assert.Equal("-sharp", dictionary["#"]);
+        Assert.Equal("-", dictionary[" "]);
+        Assert.Equal("-plus", dictionary["+"]);
+    }
+
+    [Fact]
+    public void TagNormalizationDictionary_ReturnsNewInstanceEachTime()
+    {
+        // Act
+        var dictionary1 = BlogTagHelper.TagNormalizationDictionary;
+        var dictionary2 = BlogTagHelper.TagNormalizationDictionary;
+
+        // Assert
+        Assert.NotSame(dictionary1, dictionary2);
+        Assert.Equal(dictionary1.Count, dictionary2.Count);
+    }
+
+    #endregion
+
+    #region NormalizeName Tests
+
+    [Theory]
+    [InlineData("csharp", "csharp")]
+    [InlineData("C#", "c-sharp")]
+    [InlineData("ASP.NET", "asp-net")]
+    [InlineData("F#", "f-sharp")]
+    [InlineData("C++", "c-plus-plus")]
+    [InlineData("Entity Framework", "entity-framework")]
+    [InlineData("JAVA SCRIPT", "java-script")]
+    [InlineData("Node.js", "node-js")]
+    public void NormalizeName_WithEnglishTags_NormalizesCorrectly(string input, string expected)
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(input, normalizations);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NormalizeName_WithDotNetSpecialCase_ReturnsDotNet()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result1 = BlogTagHelper.NormalizeName(".NET", normalizations);
+        var result2 = BlogTagHelper.NormalizeName(".net", normalizations);
+        var result3 = BlogTagHelper.NormalizeName(".Net", normalizations);
+
+        // Assert
+        Assert.Equal("dot-net", result1);
+        Assert.Equal("dot-net", result2);
+        Assert.Equal("dot-net", result3);
+    }
+
+    [Fact]
+    public void NormalizeName_WithChineseCharacters_ReturnsHexName()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+        const string chineseTag = "编程";
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(chineseTag, normalizations);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("-", result);
+        Assert.DoesNotContain("编程", result);
+
+        // Should be hex representation
+        var hexParts = result.Split('-');
+        Assert.All(hexParts, part =>
+        {
+            Assert.True(part.All(c => "0123456789abcdef".Contains(c)),
+                $"Part '{part}' contains non-hex characters");
+        });
+    }
+
+    [Fact]
+    public void NormalizeName_WithJapaneseCharacters_ReturnsHexName()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+        const string japaneseTag = "プログラミング";
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(japaneseTag, normalizations);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("-", result);
+        Assert.DoesNotContain("プログラミング", result);
+
+        // Should be hex representation
+        var hexParts = result.Split('-');
+        Assert.All(hexParts, part =>
+        {
+            Assert.True(part.All(c => "0123456789abcdef".Contains(c)),
+                $"Part '{part}' contains non-hex characters");
+        });
+    }
+
+    [Fact]
+    public void NormalizeName_WithMixedCharacters_ReturnsHexName()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+        const string mixedTag = "C#编程";
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(mixedTag, normalizations);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("-", result);
+
+        // Since it contains non-English characters, should return hex
+        var hexParts = result.Split('-');
+        Assert.All(hexParts, part =>
+        {
+            Assert.True(part.All(c => "0123456789abcdef".Contains(c)),
+                $"Part '{part}' contains non-hex characters");
+        });
+    }
+
+    [Fact]
+    public void NormalizeName_WithEmptyNormalizations_KeepsOriginalForEnglish()
+    {
+        // Arrange
+        var emptyNormalizations = new Dictionary<string, string>();
+
+        // Act
+        var result = BlogTagHelper.NormalizeName("simple", emptyNormalizations);
+
+        // Assert
+        Assert.Equal("simple", result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeName_WithEmptyOrWhitespaceInput_HandlesGracefully(string input)
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(input, normalizations);
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void NormalizeName_WithNullNormalizations_ThrowsException()
+    {
+        // Act & Assert
+        Assert.Throws<NullReferenceException>(() =>
+            BlogTagHelper.NormalizeName("test", null!));
+    }
+
+    [Fact]
+    public void NormalizeName_WithNumbersAndSpecialChars_NormalizesCorrectly()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result = BlogTagHelper.NormalizeName("HTML5 CSS3.0", normalizations);
+
+        // Assert
+        Assert.Equal("html5-css3-0", result);
+    }
+
+    #endregion
+
+    #region IsValidTagName Tests
+
+    [Theory]
+    [InlineData("csharp", true)]
+    [InlineData("C#", true)]
+    [InlineData("ASP.NET", true)]
+    [InlineData("javascript", true)]
+    [InlineData("HTML5", true)]
+    [InlineData("CSS 3", true)]
+    [InlineData("Node.js", true)]
+    [InlineData("C++", true)]
+    [InlineData("F#", true)]
+    [InlineData("programming123", true)]
+    [InlineData("web-dev", true)]
+    [InlineData("tag with spaces", true)]
+    [InlineData("UPPERCASE", true)]
+    [InlineData("lowercase", true)]
+    [InlineData("Mixed-Case", true)]
+    public void IsValidTagName_WithValidEnglishTags_ReturnsTrue(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("编程", true)]
+    //[InlineData("プログラミング", true)]
+    //[InlineData("개발", true)]
+    [InlineData("程式設計", true)]
+    [InlineData("软件开发", true)]
+    //[InlineData("ソフトウェア", true)]
+    public void IsValidTagName_WithValidCJKTags_ReturnsTrue(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("\t", false)]
+    [InlineData("\n", false)]
+    public void IsValidTagName_WithNullOrWhitespace_ReturnsFalse(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("tag@symbol", false)]
+    [InlineData("tag$money", false)]
+    [InlineData("tag%percent", false)]
+    [InlineData("tag^caret", false)]
+    [InlineData("tag&amp", false)]
+    [InlineData("tag*star", false)]
+    [InlineData("tag(paren", false)]
+    [InlineData("tag)paren", false)]
+    [InlineData("tag=equals", false)]
+    [InlineData("tag[bracket", false)]
+    [InlineData("tag]bracket", false)]
+    [InlineData("tag{brace", false)]
+    [InlineData("tag}brace", false)]
+    [InlineData("tag|pipe", false)]
+    [InlineData("tag\\backslash", false)]
+    [InlineData("tag:colon", false)]
+    [InlineData("tag;semicolon", false)]
+    [InlineData("tag\"quote", false)]
+    [InlineData("tag'apostrophe", false)]
+    [InlineData("tag<less", false)]
+    [InlineData("tag>greater", false)]
+    [InlineData("tag?question", false)]
+    [InlineData("tag/slash", false)]
+    [InlineData("tag,comma", false)]
+    [InlineData("tag~tilde", false)]
+    [InlineData("tag`backtick", false)]
+    public void IsValidTagName_WithInvalidCharacters_ReturnsFalse(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("مبرمج", false)] // Arabic
+    [InlineData("программирование", false)] // Russian
+    [InlineData("προγραμματισμός", false)] // Greek
+    [InlineData("프로그래밍", false)] // Korean (mixed with non-CJK)
+    [InlineData("😀emoji", false)] // Emoji
+    [InlineData("🎉party", false)] // Emoji
+    public void IsValidTagName_WithUnsupportedUnicodeCharacters_ReturnsFalse(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void IsValidTagName_WithMixedEnglishAndCJK_ReturnsFalse()
+    {
+        // Arrange
+        const string mixedTag = "C#编程";
+
+        // Act
+        var result = BlogTagHelper.IsValidTagName(mixedTag);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("a", true)] // Single character
+    [InlineData("1", true)] // Single digit
+    [InlineData(".", true)] // Single dot
+    [InlineData("#", true)] // Single hash
+    [InlineData("+", true)] // Single plus
+    [InlineData("-", true)] // Single dash
+    public void IsValidTagName_WithSingleValidCharacters_ReturnsTrue(string tagName, bool expected)
+    {
+        // Act
+        var result = BlogTagHelper.IsValidTagName(tagName);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void IsValidTagName_WithVeryLongValidTag_ReturnsTrue()
+    {
+        // Arrange
+        var longTag = new string('a', 1000);
+
+        // Act
+        var result = BlogTagHelper.IsValidTagName(longTag);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsValidTagName_PerformanceTest_ExecutesQuickly()
+    {
+        // Arrange
+        const int iterations = 10000;
+        const string testTag = "programming";
+
+        // Act
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+        {
+            BlogTagHelper.IsValidTagName(testTag);
+        }
+        stopwatch.Stop();
+
+        // Assert
+        Assert.True(stopwatch.ElapsedMilliseconds < 1000,
+            $"Performance test took {stopwatch.ElapsedMilliseconds}ms for {iterations} iterations");
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void NormalizeName_AndIsValidTagName_WorkTogether()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+        const string originalTag = "ASP.NET Core";
+
+        // Act
+        var isValid = BlogTagHelper.IsValidTagName(originalTag);
+        var normalized = BlogTagHelper.NormalizeName(originalTag, normalizations);
+
+        // Assert
+        Assert.True(isValid);
+        Assert.Equal("asp-net-core", normalized);
+    }
+
+    [Theory]
+    [InlineData(".NET Framework", "dot-net")]
+    [InlineData(".net core", "dot-net")]
+    [InlineData(".Net Standard", "dot-net")]
+    public void NormalizeName_DotNetVariations_AllReturnDotNet(string input, string expectedStart)
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(input, normalizations);
+
+        // Assert
+        Assert.StartsWith(expectedStart, result);
+    }
+
+    [Fact]
+    public void BlogTagHelper_WithRealWorldTags_HandlesCorrectly()
+    {
+        // Arrange
+        var realWorldTags = new[]
+        {
+            "C#", "JavaScript", "ASP.NET Core", "Entity Framework",
+            "HTML5", "CSS3", "Node.js", "React.js", "Vue.js",
+            "programming", "web development", "software engineering"
+        };
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act & Assert
+        foreach (var tag in realWorldTags)
+        {
+            var isValid = BlogTagHelper.IsValidTagName(tag);
+            Assert.True(isValid, $"Tag '{tag}' should be valid");
+
+            var normalized = BlogTagHelper.NormalizeName(tag, normalizations);
+            Assert.NotNull(normalized);
+            Assert.DoesNotContain(" ", normalized);
+            Assert.DoesNotContain(".", normalized);
+            Assert.DoesNotContain("#", normalized);
+            Assert.DoesNotContain("+", normalized);
+        }
+    }
+
+    #endregion
+
+    #region Edge Cases and Error Handling
+
+    [Fact]
+    public void NormalizeName_WithNullInput_ThrowsException()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            BlogTagHelper.NormalizeName(null!, normalizations));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeName_WithEmptyInput_HandlesGracefully(string input)
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+
+        // Act
+        var result = BlogTagHelper.NormalizeName(input, normalizations);
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void IsValidTagName_CJKRegexPerformance_ExecutesQuickly()
+    {
+        // Arrange
+        const int iterations = 1000;
+        const string cjkTag = "编程开发";
+
+        // Act
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+        {
+            BlogTagHelper.IsValidTagName(cjkTag);
+        }
+        stopwatch.Stop();
+
+        // Assert
+        Assert.True(stopwatch.ElapsedMilliseconds < 500,
+            $"CJK regex performance test took {stopwatch.ElapsedMilliseconds}ms for {iterations} iterations");
+    }
+
+    [Fact]
+    public void NormalizeName_WithEmptyDictionary_HandlesEnglishTagsCorrectly()
+    {
+        // Arrange
+        var emptyDict = new Dictionary<string, string>();
+
+        // Act
+        var result = BlogTagHelper.NormalizeName("Simple Tag", emptyDict);
+
+        // Assert
+        Assert.Equal("simple tag", result);
+    }
+
+    [Fact]
+    public void NormalizeName_HexConversion_IsConsistent()
+    {
+        // Arrange
+        var normalizations = BlogTagHelper.TagNormalizationDictionary;
+        const string unicodeTag = "测试";
+
+        // Act
+        var result1 = BlogTagHelper.NormalizeName(unicodeTag, normalizations);
+        var result2 = BlogTagHelper.NormalizeName(unicodeTag, normalizations);
+
+        // Assert
+        Assert.Equal(result1, result2);
+        Assert.NotEmpty(result1);
+    }
+
+    #endregion
+}

--- a/src/Moonglade.Utils.Tests/ContentProcessorTests.cs
+++ b/src/Moonglade.Utils.Tests/ContentProcessorTests.cs
@@ -483,7 +483,7 @@ public class ContentProcessorTests
         const ContentProcessor.MarkdownConvertType invalidType = (ContentProcessor.MarkdownConvertType)999;
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => 
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
             ContentProcessor.MarkdownToContent(markdown, invalidType));
     }
 

--- a/src/Moonglade.Utils.Tests/Moonglade.Utils.Tests.csproj
+++ b/src/Moonglade.Utils.Tests/Moonglade.Utils.Tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Moonglade.Utils.Tests/SecurityHelperTests.cs
+++ b/src/Moonglade.Utils.Tests/SecurityHelperTests.cs
@@ -1,0 +1,439 @@
+namespace Moonglade.Utils.Tests;
+
+public class SecurityHelperTests
+{
+    #region HashPassword Tests
+
+    [Fact]
+    public void HashPassword_WithValidPasswordAndSalt_ReturnsHashedPassword()
+    {
+        // Arrange
+        const string password = "testPassword123";
+        const string salt = "dGVzdFNhbHQ="; // base64 encoded "testSalt"
+
+        // Act
+        var result = SecurityHelper.HashPassword(password, salt);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.NotEqual(password, result);
+    }
+
+    [Fact]
+    public void HashPassword_WithSamePasswordAndSalt_ReturnsConsistentHash()
+    {
+        // Arrange
+        const string password = "testPassword123";
+        const string salt = "dGVzdFNhbHQ=";
+
+        // Act
+        var result1 = SecurityHelper.HashPassword(password, salt);
+        var result2 = SecurityHelper.HashPassword(password, salt);
+
+        // Assert
+        Assert.Equal(result1, result2);
+    }
+
+    [Fact]
+    public void HashPassword_WithDifferentPasswords_ReturnsDifferentHashes()
+    {
+        // Arrange
+        const string password1 = "password1";
+        const string password2 = "password2";
+        const string salt = "dGVzdFNhbHQ=";
+
+        // Act
+        var result1 = SecurityHelper.HashPassword(password1, salt);
+        var result2 = SecurityHelper.HashPassword(password2, salt);
+
+        // Assert
+        Assert.NotEqual(result1, result2);
+    }
+
+    [Fact]
+    public void HashPassword_WithDifferentSalts_ReturnsDifferentHashes()
+    {
+        // Arrange
+        const string password = "testPassword";
+        const string salt1 = "c2FsdDE="; // base64 encoded "salt1"
+        const string salt2 = "c2FsdDI="; // base64 encoded "salt2"
+
+        // Act
+        var result1 = SecurityHelper.HashPassword(password, salt1);
+        var result2 = SecurityHelper.HashPassword(password, salt2);
+
+        // Assert
+        Assert.NotEqual(result1, result2);
+    }
+
+    [Fact]
+    public void HashPassword_ReturnsBase64EncodedString()
+    {
+        // Arrange
+        const string password = "testPassword";
+        const string salt = "dGVzdFNhbHQ=";
+
+        // Act
+        var result = SecurityHelper.HashPassword(password, salt);
+
+        // Assert
+        Exception ex = Record.Exception(() => Convert.FromBase64String(salt));
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("  ")]
+    public void HashPassword_WithEmptyOrWhitespacePassword_HandlesGracefully(string password)
+    {
+        // Arrange
+        const string salt = "dGVzdFNhbHQ=";
+
+        // Act & Assert
+        var result = SecurityHelper.HashPassword(password, salt);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void HashPassword_WithInvalidBase64Salt_ThrowsFormatException()
+    {
+        // Arrange
+        const string password = "testPassword";
+        const string invalidSalt = "invalid!base64!";
+
+        // Act & Assert
+        Assert.Throws<FormatException>(() => SecurityHelper.HashPassword(password, invalidSalt));
+    }
+
+    #endregion
+
+    #region GenerateSalt Tests
+
+    [Fact]
+    public void GenerateSalt_ReturnsNonEmptyString()
+    {
+        // Act
+        var salt = SecurityHelper.GenerateSalt();
+
+        // Assert
+        Assert.NotNull(salt);
+        Assert.NotEmpty(salt);
+    }
+
+    [Fact]
+    public void GenerateSalt_ReturnsValidBase64String()
+    {
+        // Act
+        var salt = SecurityHelper.GenerateSalt();
+
+        // Assert
+        Exception ex = Record.Exception(() => Convert.FromBase64String(salt));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void GenerateSalt_ReturnsCorrectByteLength()
+    {
+        // Act
+        var salt = SecurityHelper.GenerateSalt();
+        var bytes = Convert.FromBase64String(salt);
+
+        // Assert
+        Assert.Equal(16, bytes.Length); // 128 bits / 8 = 16 bytes
+    }
+
+    [Fact]
+    public void GenerateSalt_ReturnsDifferentValuesOnMultipleCalls()
+    {
+        // Act
+        var salt1 = SecurityHelper.GenerateSalt();
+        var salt2 = SecurityHelper.GenerateSalt();
+        var salt3 = SecurityHelper.GenerateSalt();
+
+        // Assert
+        Assert.NotEqual(salt1, salt2);
+        Assert.NotEqual(salt2, salt3);
+        Assert.NotEqual(salt1, salt3);
+    }
+
+    [Fact]
+    public void GenerateSalt_GeneratesHighEntropyValues()
+    {
+        // Arrange
+        var salts = new HashSet<string>();
+
+        // Act - Generate 100 salts
+        for (int i = 0; i < 100; i++)
+        {
+            salts.Add(SecurityHelper.GenerateSalt());
+        }
+
+        // Assert - All should be unique
+        Assert.Equal(100, salts.Count);
+    }
+
+    #endregion
+
+    #region SterilizeLink Tests
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void SterilizeLink_WithNullOrWhitespaceInput_ReturnsHash(string input)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(input!);
+
+        // Assert
+        Assert.Equal("#", result);
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/home")]
+    [InlineData("/about")]
+    [InlineData("/posts/123")]
+    [InlineData("/api/v1/data")]
+    public void SterilizeLink_WithValidLocalPaths_ReturnsOriginalPath(string path)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(path);
+
+        // Assert
+        Assert.Equal(path, result);
+    }
+
+    [Theory]
+    [InlineData("//")]
+    [InlineData("//evil.com")]
+    [InlineData("/\\")]
+    [InlineData("/\\evil.com")]
+    [InlineData("//\\evil.com")]
+    public void SterilizeLink_WithMaliciousLocalPaths_ReturnsHash(string maliciousPath)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(maliciousPath);
+
+        // Assert
+        Assert.Equal("#", result);
+    }
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    [InlineData("https://subdomain.example.com/path")]
+    [InlineData("https://example.com:8080/api")]
+    public void SterilizeLink_WithValidExternalUrls_ReturnsOriginalUrl(string url)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(url);
+
+        // Assert
+        Assert.Equal(url, result);
+    }
+
+    [Theory]
+    [InlineData("http://localhost")]
+    [InlineData("https://localhost:8080")]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("https://127.0.0.1:443")]
+    public void SterilizeLink_WithLoopbackUrls_ReturnsHash(string loopbackUrl)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(loopbackUrl);
+
+        // Assert
+        Assert.Equal("#", result);
+    }
+
+    [Theory]
+    [InlineData("http://192.168.1.1")]
+    [InlineData("https://192.168.0.100")]
+    [InlineData("http://10.0.0.1")]
+    [InlineData("https://10.255.255.255")]
+    [InlineData("http://172.16.0.1")]
+    [InlineData("https://172.31.255.255")]
+    public void SterilizeLink_WithPrivateIpUrls_ReturnsHash(string privateIpUrl)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(privateIpUrl);
+
+        // Assert
+        Assert.Equal("#", result);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("not a url at all")]
+    [InlineData("ftp://example.com")]
+    [InlineData("javascript:alert('xss')")]
+    public void SterilizeLink_WithInvalidUrls_ReturnsHash(string invalidUrl)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(invalidUrl);
+
+        // Assert
+        Assert.Equal("#", result);
+    }
+
+    [Theory]
+    [InlineData("http://8.8.8.8")]
+    [InlineData("https://1.1.1.1")]
+    [InlineData("http://173.252.74.22")] // Facebook IP
+    public void SterilizeLink_WithPublicIpUrls_ReturnsOriginalUrl(string publicIpUrl)
+    {
+        // Act
+        var result = SecurityHelper.SterilizeLink(publicIpUrl);
+
+        // Assert
+        Assert.Equal(publicIpUrl, result);
+    }
+
+    #endregion
+
+    #region IsPrivateIP Tests
+
+    [Theory]
+    [InlineData("192.168.1.1", true)]
+    [InlineData("192.168.0.255", true)]
+    [InlineData("192.168.255.255", true)]
+    [InlineData("10.0.0.1", true)]
+    [InlineData("10.255.255.255", true)]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("127.255.255.255", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.255", true)]
+    public void IsPrivateIP_WithPrivateIPs_ReturnsTrue(string ip, bool expected)
+    {
+        // Act
+        var result = SecurityHelper.IsPrivateIP(ip);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("1.1.1.1", false)]
+    [InlineData("173.252.74.22", false)] // Facebook
+    [InlineData("151.101.193.140", false)] // Reddit
+    [InlineData("172.15.255.255", false)] // Just outside private range
+    [InlineData("172.32.0.1", false)] // Just outside private range
+    [InlineData("193.168.1.1", false)] // Close to 192.168 but public
+    [InlineData("11.0.0.1", false)] // Close to 10.x but public
+    public void IsPrivateIP_WithPublicIPs_ReturnsFalse(string ip, bool expected)
+    {
+        // Act
+        var result = SecurityHelper.IsPrivateIP(ip);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("172.16.0.0")]
+    [InlineData("172.16.255.255")]
+    [InlineData("172.20.0.0")]
+    [InlineData("172.25.128.1")]
+    [InlineData("172.31.0.0")]
+    [InlineData("172.31.255.255")]
+    public void IsPrivateIP_WithClass172PrivateRange_ReturnsTrue(string ip)
+    {
+        // Act
+        var result = SecurityHelper.IsPrivateIP(ip);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("172.15.255.255")]
+    [InlineData("172.32.0.0")]
+    [InlineData("172.0.0.1")]
+    [InlineData("172.50.0.1")]
+    public void IsPrivateIP_WithClass172PublicRange_ReturnsFalse(string ip)
+    {
+        // Act
+        var result = SecurityHelper.IsPrivateIP(ip);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("invalid.ip")]
+    [InlineData("256.256.256.256")]
+    [InlineData("")]
+    [InlineData("192.168.1.1.1")]
+    public void IsPrivateIP_WithInvalidIPFormats_ThrowsFormatException(string invalidIp)
+    {
+        // Act & Assert
+        Assert.Throws<FormatException>(() => SecurityHelper.IsPrivateIP(invalidIp));
+    }
+
+    [Fact]
+    public void IsPrivateIP_WithNullInput_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => SecurityHelper.IsPrivateIP(null!));
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void SecurityHelper_PasswordHashingWorkflow_WorksCorrectly()
+    {
+        // Arrange
+        const string originalPassword = "MySecurePassword123!";
+
+        // Act - Generate salt and hash password
+        var salt = SecurityHelper.GenerateSalt();
+        var hashedPassword = SecurityHelper.HashPassword(originalPassword, salt);
+
+        // Verify the same password with same salt produces same hash
+        var verificationHash = SecurityHelper.HashPassword(originalPassword, salt);
+
+        // Assert
+        Assert.Equal(hashedPassword, verificationHash);
+        Assert.NotEqual(originalPassword, hashedPassword);
+    }
+
+    [Fact]
+    public void SecurityHelper_LinkSterilization_HandlesComplexScenarios()
+    {
+        // Arrange & Act & Assert
+        Assert.Equal("https://example.com/safe", SecurityHelper.SterilizeLink("https://example.com/safe"));
+        Assert.Equal("#", SecurityHelper.SterilizeLink("http://192.168.1.1/malicious"));
+        Assert.Equal("/safe/local/path", SecurityHelper.SterilizeLink("/safe/local/path"));
+        Assert.Equal("#", SecurityHelper.SterilizeLink("//malicious.com"));
+        Assert.Equal("#", SecurityHelper.SterilizeLink("javascript:alert('xss')"));
+    }
+
+    [Theory]
+    [InlineData("192.168.1.100")]
+    [InlineData("10.0.0.50")]
+    [InlineData("172.20.5.1")]
+    [InlineData("127.0.0.1")]
+    public void SecurityHelper_PrivateIPDetection_IntegratesWithSterilizeLink(string privateIp)
+    {
+        // Arrange
+        var url = $"http://{privateIp}/test";
+
+        // Act
+        var sterilizedResult = SecurityHelper.SterilizeLink(url);
+        var isPrivateResult = SecurityHelper.IsPrivateIP(privateIp);
+
+        // Assert
+        Assert.True(isPrivateResult);
+        Assert.Equal("#", sterilizedResult);
+    }
+
+    #endregion
+}

--- a/src/Moonglade.Utils.Tests/UrlExtensionTests.cs
+++ b/src/Moonglade.Utils.Tests/UrlExtensionTests.cs
@@ -42,7 +42,7 @@ public class UrlExtensionTests
     public void IsValidUrl_WithNullUrl_ReturnsFalse()
     {
         // Arrange
-        string? url = null;
+        string url = null;
 
         // Act
         var result = url.IsValidUrl();
@@ -105,7 +105,7 @@ public class UrlExtensionTests
     [InlineData("https://example.com", "")]
     [InlineData("   ", "path")]
     [InlineData("https://example.com", "   ")]
-    public void CombineUrl_WithNullOrEmptyInputs_ThrowsArgumentNullException(string? baseUrl, string? path)
+    public void CombineUrl_WithNullOrEmptyInputs_ThrowsArgumentNullException(string baseUrl, string path)
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => baseUrl!.CombineUrl(path!));

--- a/src/Moonglade.Utils.Tests/UrlHelperTests.cs
+++ b/src/Moonglade.Utils.Tests/UrlHelperTests.cs
@@ -1,0 +1,463 @@
+using Microsoft.AspNetCore.Http;
+using System.Globalization;
+
+namespace Moonglade.Utils.Tests;
+
+public class UrlHelperTests
+{
+    #region GetRouteLinkFromUrl Tests
+
+    [Theory]
+    [InlineData("https://example.com/post/2023/12/25/my-blog-post", "2023/12/25/my-blog-post")]
+    [InlineData("http://blog.com/post/2022/1/1/new-year-post", "2022/1/1/new-year-post")]
+    [InlineData("https://myblog.net/post/2024/6/15/summer-vacation", "2024/6/15/summer-vacation")]
+    [InlineData("http://localhost:5000/post/2023/3/8/local-test", "2023/3/8/local-test")]
+    [InlineData("https://subdomain.example.com/post/2023/12/31/year-end-summary", "2023/12/31/year-end-summary")]
+    public void GetRouteLinkFromUrl_WithValidUrls_ReturnsCorrectRouteLink(string url, string expected)
+    {
+        // Act
+        var result = UrlHelper.GetRouteLinkFromUrl(url);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/invalid/path")]
+    [InlineData("https://example.com/post/")]
+    [InlineData("https://example.com/post/2023")]
+    [InlineData("https://example.com/post/2023/12")]
+    [InlineData("https://example.com/post/2023/12/25")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com/post/2023/12/25/test")]
+    [InlineData("")]
+    public void GetRouteLinkFromUrl_WithInvalidUrls_ThrowsFormatException(string url)
+    {
+        // Act & Assert
+        var exception = Assert.Throws<FormatException>(() => UrlHelper.GetRouteLinkFromUrl(url));
+        Assert.Equal("Invalid Slug Format", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/post/2023/13/25/invalid-month")]
+    [InlineData("https://example.com/post/2023/12/32/invalid-day")]
+    [InlineData("https://example.com/post/abcd/12/25/invalid-year")]
+    public void GetRouteLinkFromUrl_WithInvalidDateComponents_ThrowsFormatException(string url)
+    {
+        // Act & Assert
+        var exception = Assert.Throws<FormatException>(() => UrlHelper.GetRouteLinkFromUrl(url));
+        Assert.Equal("Invalid Slug Format", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/post/2023/12/25/MY-BLOG-POST", "2023/12/25/my-blog-post")]
+    [InlineData("https://example.com/post/2023/12/25/CamelCasePost", "2023/12/25/camelcasepost")]
+    public void GetRouteLinkFromUrl_WithUpperCaseSlug_ReturnsLowerCaseResult(string url, string expected)
+    {
+        // Act
+        var result = UrlHelper.GetRouteLinkFromUrl(url);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region GetUrlsFromContent Tests
+
+    [Theory]
+    [InlineData("<a href=\"https://example.com\">Link</a>", 1)]
+    [InlineData("<a href='http://test.com'>Test</a>", 1)]
+    [InlineData("<a href=\"https://example.com\">Link1</a> and <a href=\"http://test.com\">Link2</a>", 2)]
+    [InlineData("No links here", 0)]
+    public void GetUrlsFromContent_WithValidContent_ReturnsCorrectNumberOfUrls(string content, int expectedCount)
+    {
+        // Act
+        var result = UrlHelper.GetUrlsFromContent(content);
+
+        // Assert
+        Assert.Equal(expectedCount, result.Count());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void GetUrlsFromContent_WithNullOrWhitespaceContent_ThrowsArgumentNullException(string content)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => UrlHelper.GetUrlsFromContent(content!));
+    }
+
+    [Fact]
+    public void GetUrlsFromContent_WithValidUrls_ReturnsCorrectUris()
+    {
+        // Arrange
+        const string content = "<a href=\"https://example.com\">Example</a> and <a href=\"http://test.com/path\">Test</a>";
+
+        // Act
+        var result = UrlHelper.GetUrlsFromContent(content).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, uri => uri.ToString() == "https://example.com/");
+        Assert.Contains(result, uri => uri.ToString() == "http://test.com/path");
+    }
+
+    [Theory]
+    [InlineData("<a href=\"invalid-url\">Invalid</a>")]
+    [InlineData("<a href=\"javascript:alert('xss')\">Malicious</a>")]
+    [InlineData("<a href=\"/relative/path\">Relative</a>")]
+    [InlineData("<a href=\"#anchor\">Anchor</a>")]
+    public void GetUrlsFromContent_WithInvalidUrls_FiltersOutInvalidOnes(string content)
+    {
+        // Act
+        var result = UrlHelper.GetUrlsFromContent(content);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetUrlsFromContent_WithMixedValidAndInvalidUrls_ReturnsOnlyValidOnes()
+    {
+        // Arrange
+        const string content = """
+            <a href="https://valid.com">Valid</a>
+            <a href="invalid-url">Invalid</a>
+            <a href="http://another-valid.com">Another Valid</a>
+            <a href="/relative">Relative</a>
+            """;
+
+        // Act
+        var result = UrlHelper.GetUrlsFromContent(content).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, uri => uri.ToString() == "https://valid.com/");
+        Assert.Contains(result, uri => uri.ToString() == "http://another-valid.com/");
+    }
+
+    [Theory]
+    [InlineData("<A HREF=\"https://example.com\">Upper Case</A>")]
+    [InlineData("<a HREF=\"https://example.com\">Mixed Case</a>")]
+    [InlineData("<a href=\"https://example.com\" target=\"_blank\">With Attributes</a>")]
+    public void GetUrlsFromContent_WithVariousHtmlFormats_ExtractsUrls(string content)
+    {
+        // Act
+        var result = UrlHelper.GetUrlsFromContent(content);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("https://example.com/", result.First().ToString());
+    }
+
+    #endregion
+
+    #region GenerateRouteLink Tests
+
+    [Theory]
+    [InlineData("2023-12-25", "my-blog-post", "2023/12/25/my-blog-post")]
+    [InlineData("2022-01-01", "new-year-post", "2022/1/1/new-year-post")]
+    [InlineData("2024-06-15", "summer-vacation", "2024/6/15/summer-vacation")]
+    [InlineData("2023-03-08", "test-post", "2023/3/8/test-post")]
+    public void GenerateRouteLink_WithValidInputs_ReturnsCorrectRoute(string dateString, string slug, string expected)
+    {
+        // Arrange
+        var publishDate = DateTime.Parse(dateString, CultureInfo.InvariantCulture);
+
+        // Act
+        var result = UrlHelper.GenerateRouteLink(publishDate, slug);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void GenerateRouteLink_WithNullOrWhitespaceSlug_ThrowsArgumentNullException(string slug)
+    {
+        // Arrange
+        var publishDate = new DateTime(2023, 12, 25);
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => UrlHelper.GenerateRouteLink(publishDate, slug!));
+        Assert.Equal("slug", exception.ParamName);
+        Assert.Contains("Slug must not be null or empty.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("MY-BLOG-POST", "my-blog-post")]
+    [InlineData("CamelCasePost", "camelcasepost")]
+    [InlineData("UPPERCASE", "uppercase")]
+    public void GenerateRouteLink_WithUpperCaseSlug_ReturnsLowerCaseSlug(string slug, string expectedSlug)
+    {
+        // Arrange
+        var publishDate = new DateTime(2023, 12, 25);
+        var expectedResult = $"2023/12/25/{expectedSlug}";
+
+        // Act
+        var result = UrlHelper.GenerateRouteLink(publishDate, slug);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Fact]
+    public void GenerateRouteLink_WithMinDateTime_HandlesCorrectly()
+    {
+        // Arrange
+        var publishDate = DateTime.MinValue;
+        const string slug = "test-post";
+
+        // Act
+        var result = UrlHelper.GenerateRouteLink(publishDate, slug);
+
+        // Assert
+        Assert.Equal("0001/1/1/test-post", result);
+    }
+
+    [Fact]
+    public void GenerateRouteLink_WithMaxDateTime_HandlesCorrectly()
+    {
+        // Arrange
+        var publishDate = DateTime.MaxValue;
+        const string slug = "test-post";
+
+        // Act
+        var result = UrlHelper.GenerateRouteLink(publishDate, slug);
+
+        // Assert
+        Assert.Equal("9999/12/31/test-post", result);
+    }
+
+    #endregion
+
+    #region GetDNSPrefetchUrl Tests
+
+    [Theory]
+    [InlineData("https://cdn.example.com/assets", "https://cdn.example.com/")]
+    [InlineData("http://cdn.test.com/images", "http://cdn.test.com/")]
+    [InlineData("https://static.myblog.com:8080/content", "https://static.myblog.com:8080/")]
+    [InlineData("http://localhost:3000", "http://localhost:3000/")]
+    public void GetDNSPrefetchUrl_WithValidCdnEndpoints_ReturnsCorrectPrefetchUrl(string cdnEndpoint, string expected)
+    {
+        // Act
+        var result = UrlHelper.GetDNSPrefetchUrl(cdnEndpoint);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void GetDNSPrefetchUrl_WithNullOrWhitespaceCdnEndpoint_ReturnsEmptyString(string cdnEndpoint)
+    {
+        // Act
+        var result = UrlHelper.GetDNSPrefetchUrl(cdnEndpoint!);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("not-a-url")]
+    public void GetDNSPrefetchUrl_WithInvalidCdnEndpoint_ThrowsUriFormatException(string cdnEndpoint)
+    {
+        // Act & Assert
+        Assert.Throws<UriFormatException>(() => UrlHelper.GetDNSPrefetchUrl(cdnEndpoint));
+    }
+
+    #endregion
+
+    #region ResolveRootUrl Tests
+
+    [Fact]
+    public void ResolveRootUrl_WithNullContextAndPreferCanonicalFalse_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => 
+            UrlHelper.ResolveRootUrl(null!, "https://canonical.com", false));
+        Assert.Equal("ctx", exception.ParamName);
+        Assert.Contains("HttpContext must not be null when preferCanonical is 'false'", exception.Message);
+    }
+
+    [Fact]
+    public void ResolveRootUrl_WithPreferCanonicalTrue_ReturnsCanonicalUrl()
+    {
+        // Arrange
+        const string canonicalPrefix = "https://canonical.com";
+
+        // Act
+        var result = UrlHelper.ResolveRootUrl(null!, canonicalPrefix, true);
+
+        // Assert
+        Assert.Equal("https://canonical.com/", result);
+    }
+
+    [Fact]
+    public void ResolveRootUrl_WithValidHttpContext_ReturnsRequestUrl()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("example.com");
+
+        // Act
+        var result = UrlHelper.ResolveRootUrl(context, "https://canonical.com", false);
+
+        // Assert
+        Assert.Equal("https://example.com", result);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/", true, "https://example.com")]
+    [InlineData("https://example.com", true, "https://example.com")]
+    [InlineData("https://example.com/", false, "https://example.com/")]
+    [InlineData("https://example.com", false, "https://example.com/")]
+    public void ResolveRootUrl_WithRemoveTailSlashOption_HandlesTrailingSlashCorrectly(string canonicalPrefix, bool removeTailSlash, string expected)
+    {
+        // Act
+        var result = UrlHelper.ResolveRootUrl(null!, canonicalPrefix, true, removeTailSlash);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region ResolveCanonicalUrl Tests
+
+    [Theory]
+    [InlineData("https://example.com", "", "https://example.com/")]
+    [InlineData("https://example.com", "blog/post", "https://example.com/blog/post")]
+    [InlineData("https://example.com/", "blog/post", "https://example.com/blog/post")]
+    [InlineData("https://example.com", "/blog/post", "https://example.com/blog/post")]
+    [InlineData("https://example.com:8080", "api/v1", "https://example.com:8080/api/v1")]
+    public void ResolveCanonicalUrl_WithValidInputs_ReturnsCorrectUrl(string prefix, string path, string expected)
+    {
+        // Act
+        var result = UrlHelper.ResolveCanonicalUrl(prefix, path);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void ResolveCanonicalUrl_WithNullOrWhitespacePrefix_ReturnsEmptyString(string prefix)
+    {
+        // Act
+        var result = UrlHelper.ResolveCanonicalUrl(prefix!, "some/path");
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void ResolveCanonicalUrl_WithNullPath_HandlesGracefully()
+    {
+        // Act
+        var result = UrlHelper.ResolveCanonicalUrl("https://example.com", null!);
+
+        // Assert
+        Assert.Equal("https://example.com/", result);
+    }
+
+    [Theory]
+    [InlineData("invalid-url")]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com")]
+    [InlineData("javascript:alert('xss')")]
+    public void ResolveCanonicalUrl_WithInvalidPrefix_ThrowsUriFormatException(string prefix)
+    {
+        // Act & Assert
+        var exception = Assert.Throws<UriFormatException>(() => UrlHelper.ResolveCanonicalUrl(prefix, "path"));
+        Assert.Contains($"Prefix '{prefix}' is not a valid URL.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("https://example.com", "invalid path with spaces")]
+    [InlineData("https://example.com", "path with | invalid chars")]
+    public void ResolveCanonicalUrl_WithInvalidPath_ReturnsEmptyString(string prefix, string path)
+    {
+        // Act
+        var result = UrlHelper.ResolveCanonicalUrl(prefix, path);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    #endregion
+
+    #region Edge Cases and Integration Tests
+
+    [Fact]
+    public void UrlHelper_AllMethods_HandleUnicodeCharactersCorrectly()
+    {
+        // Test GenerateRouteLink with unicode
+        var unicodeSlug = "≤‚ ‘-post";
+        var publishDate = new DateTime(2023, 12, 25);
+        var routeResult = UrlHelper.GenerateRouteLink(publishDate, unicodeSlug);
+        Assert.Equal("2023/12/25/≤‚ ‘-post", routeResult);
+
+        // Test ResolveCanonicalUrl with unicode path
+        var canonicalResult = UrlHelper.ResolveCanonicalUrl("https://example.com", "≤‚ ‘/path");
+        Assert.Equal("https://example.com/≤‚ ‘/path", canonicalResult);
+    }
+
+    [Fact]
+    public void UrlHelper_WithComplexHtmlContent_ExtractsAllValidUrls()
+    {
+        // Arrange
+        const string complexHtml = """
+            <div>
+                <a href="https://example.com">Main Site</a>
+                <p>Check out <a href="http://blog.example.com/post/1">this post</a></p>
+                <span><a href="https://cdn.example.com/image.jpg">Image</a></span>
+                <a href="/relative/link">Relative</a>
+                <a href="mailto:test@example.com">Email</a>
+                <a href="javascript:void(0)">JavaScript</a>
+            </div>
+            """;
+
+        // Act
+        var urls = UrlHelper.GetUrlsFromContent(complexHtml).ToList();
+
+        // Assert
+        Assert.Equal(3, urls.Count);
+        Assert.Contains(urls, uri => uri.ToString() == "https://example.com/");
+        Assert.Contains(urls, uri => uri.ToString() == "http://blog.example.com/post/1");
+        Assert.Contains(urls, uri => uri.ToString() == "https://cdn.example.com/image.jpg");
+    }
+
+    [Fact]
+    public void UrlHelper_RegexPerformance_HandlesLargeContent()
+    {
+        // Arrange - Create large content with many links
+        var largeContent = string.Join("\n", 
+            Enumerable.Range(1, 1000)
+                .Select(i => $"<a href=\"https://example{i}.com\">Link {i}</a>"));
+
+        // Act & Assert - Should complete without timeout
+        var urls = UrlHelper.GetUrlsFromContent(largeContent);
+        Assert.Equal(1000, urls.Count());
+    }
+
+    #endregion
+}

--- a/src/Moonglade.Utils.Tests/VersionHelperTests.cs
+++ b/src/Moonglade.Utils.Tests/VersionHelperTests.cs
@@ -71,7 +71,7 @@ public class VersionHelperTests
 
         // Assert
         Assert.NotNull(result);
-        
+
         // If the version contains a git hash (indicated by parentheses), 
         // it should be properly formatted
         if (result.Contains('(') && result.Contains(')'))
@@ -128,7 +128,7 @@ public class VersionHelperTests
         // This tests the regex pattern logic directly
 
         // Arrange
-        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex", 
+        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex",
             BindingFlags.NonPublic | BindingFlags.Static);
         var regex = regexMethod?.Invoke(null, null) as System.Text.RegularExpressions.Regex;
 
@@ -161,10 +161,10 @@ public class VersionHelperTests
         // Assert
         Assert.NotEmpty(appVersion);
         Assert.NotEmpty(appVersionBasic);
-        
+
         // AppVersion should either be the same as AppVersionBasic (when no informational version)
         // or contain additional formatting (git hash in parentheses)
-        Assert.True(appVersion == appVersionBasic || 
+        Assert.True(appVersion == appVersionBasic ||
                    appVersion.StartsWith(appVersionBasic.Split('.')[0]) ||
                    appVersion.Contains('('));
     }
@@ -181,10 +181,10 @@ public class VersionHelperTests
             var startIndex = appVersion.IndexOf('(') + 1;
             var endIndex = appVersion.IndexOf(')', startIndex);
             var gitHash = appVersion.Substring(startIndex, endIndex - startIndex);
-            
+
             // Git hash should be exactly 6 characters when shortened
             Assert.Equal(6, gitHash.Length);
-            
+
             // Should be hexadecimal characters
             Assert.Matches("^[a-f0-9]{6}$", gitHash.ToLowerInvariant());
         }
@@ -206,7 +206,7 @@ public class VersionHelperTests
     public void NonStableVersionRegex_WithSingleKeywords_MatchesCorrectly(string keyword)
     {
         // Arrange
-        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex", 
+        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex",
             BindingFlags.NonPublic | BindingFlags.Static);
         var regex = regexMethod?.Invoke(null, null) as System.Text.RegularExpressions.Regex;
 
@@ -227,7 +227,7 @@ public class VersionHelperTests
     public void NonStableVersionRegex_WithStableKeywords_DoesNotMatch(string stableVersion)
     {
         // Arrange
-        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex", 
+        var regexMethod = typeof(VersionHelper).GetMethod("NonStableVersionRegex",
             BindingFlags.NonPublic | BindingFlags.Static);
         var regex = regexMethod?.Invoke(null, null) as System.Text.RegularExpressions.Regex;
 

--- a/src/Moonglade.Utils/BlogTagHelper.cs
+++ b/src/Moonglade.Utils/BlogTagHelper.cs
@@ -19,9 +19,9 @@ public static class BlogTagHelper
         if (isEnglishName)
         {
             // special case
-            if (orgTagName.Equals(".net", StringComparison.OrdinalIgnoreCase))
+            if (orgTagName.StartsWith(".net", StringComparison.OrdinalIgnoreCase))
             {
-                return "dot-net";
+                orgTagName = orgTagName.ToLowerInvariant().Replace(".net", "dot-net");
             }
 
             var result = new StringBuilder(orgTagName);
@@ -51,7 +51,7 @@ public static class BlogTagHelper
         if (isEng) return true;
 
         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#supported-named-blocks
-        const string chsPattern = @"\p{IsCJKUnifiedIdeographs}";
+        const string chsPattern = @"^[\p{IsCJKUnifiedIdeographs}]*$";
         var isChs = Regex.IsMatch(tagDisplayName, chsPattern);
 
         return isChs;

--- a/src/Moonglade.Utils/Helper.cs
+++ b/src/Moonglade.Utils/Helper.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.AspNetCore.Cryptography.KeyDerivation;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Win32;
 using System.Globalization;
-using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
@@ -120,30 +118,6 @@ public static class Helper
         return $"{uri.Scheme}://{uri.Host}/";
     }
 
-    // https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/consumer-apis/password-hashing?view=aspnetcore-6.0
-    // This is not secure, but better than nothing.
-    public static string HashPassword(string clearPassword, string saltBase64)
-    {
-        var salt = Convert.FromBase64String(saltBase64);
-
-        // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
-        string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
-            password: clearPassword!,
-            salt: salt,
-            prf: KeyDerivationPrf.HMACSHA256,
-            iterationCount: 100000,
-            numBytesRequested: 256 / 8));
-
-        return hashed;
-    }
-
-    public static string GenerateSalt()
-    {
-        // Generate a 128-bit salt using a sequence of cryptographically strong random bytes.
-        byte[] salt = RandomNumberGenerator.GetBytes(128 / 8); // divide by 8 to convert bits to bytes
-        return Convert.ToBase64String(salt);
-    }
-
     public static string ResolveRootUrl(HttpContext ctx, string canonicalPrefix, bool preferCanonical = false, bool removeTailSlash = false)
     {
         if (ctx is null && !preferCanonical)
@@ -163,56 +137,6 @@ public static class Helper
         return url;
     }
 
-    public static string SterilizeLink(string rawUrl)
-    {
-        bool IsUnderLocalSlash()
-        {
-            // Allows "/" or "/foo" but not "//" or "/\".
-            if (rawUrl[0] == '/')
-            {
-                // url is exactly "/"
-                if (rawUrl.Length == 1)
-                {
-                    return true;
-                }
-
-                // url doesn't start with "//" or "/\"
-                return rawUrl[1] is not '/' and not '\\';
-            }
-
-            return false;
-        }
-
-        string invalidReturn = "#";
-        if (string.IsNullOrWhiteSpace(rawUrl))
-        {
-            return invalidReturn;
-        }
-
-        if (!rawUrl.IsValidUrl())
-        {
-            return IsUnderLocalSlash() ? rawUrl : invalidReturn;
-        }
-
-        var uri = new Uri(rawUrl);
-        if (uri.IsLoopback)
-        {
-            // localhost, 127.0.0.1
-            return invalidReturn;
-        }
-
-        if (uri.HostNameType == UriHostNameType.IPv4)
-        {
-            // Disallow LAN IP (e.g. 192.168.0.1, 10.0.0.1)
-            if (IsPrivateIP(uri.Host))
-            {
-                return invalidReturn;
-            }
-        }
-
-        return rawUrl;
-    }
-
     public static string ResolveCanonicalUrl(string prefix, string path)
     {
         if (string.IsNullOrWhiteSpace(prefix)) return string.Empty;
@@ -228,23 +152,6 @@ public static class Helper
             newUri.ToString() :
             string.Empty;
     }
-
-    /// <summary>
-    /// Test an IPv4 address is LAN or not.
-    /// </summary>
-    /// <param name="ip">IPv4 address</param>
-    /// <returns>bool</returns>
-    public static bool IsPrivateIP(string ip) => IPAddress.Parse(ip).GetAddressBytes() switch
-    {
-        // Regex.IsMatch(ip, @"(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)")
-        // Regex has bad performance, this is better
-
-        var x when x[0] is 192 && x[1] is 168 => true,
-        var x when x[0] is 10 => true,
-        var x when x[0] is 127 => true,
-        var x when x[0] is 172 && x[1] is >= 16 and <= 31 => true,
-        _ => false
-    };
 
     public static string FormatCopyright2Html(string copyrightCode)
     {

--- a/src/Moonglade.Utils/Helper.cs
+++ b/src/Moonglade.Utils/Helper.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Win32;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
@@ -42,46 +41,6 @@ public static class Helper
         return useServerSideDarkMode;
     }
 
-    public static string GetRouteLinkFromUrl(string url)
-    {
-        var blogSlugRegex = new Regex(@"^https?:\/\/.*\/post\/(?<yyyy>\d{4})\/(?<MM>\d{1,12})\/(?<dd>\d{1,31})\/(?<slug>.*)$");
-        Match match = blogSlugRegex.Match(url);
-        if (!match.Success)
-        {
-            throw new FormatException("Invalid Slug Format");
-        }
-
-        string yyyy = match.Groups["yyyy"].Value;
-        string mm = match.Groups["MM"].Value;
-        string dd = match.Groups["dd"].Value;
-        string slug = match.Groups["slug"].Value;
-
-        return $"{yyyy}/{mm}/{dd}/{slug}".ToLower();
-    }
-
-    private static readonly Regex UrlsRegex = new(
-        @"<a.*?href=[""'](?<url>.*?)[""'].*?>(?<name>.*?)</a>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    public static IEnumerable<Uri> GetUrlsFromContent(string content)
-    {
-        if (string.IsNullOrWhiteSpace(content))
-        {
-            throw new ArgumentNullException(content);
-        }
-
-        var urlsList = new List<Uri>();
-        foreach (var url in
-                 UrlsRegex.Matches(content).Select(myMatch => myMatch.Groups["url"].ToString().Trim()))
-        {
-            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            {
-                urlsList.Add(uri);
-            }
-        }
-
-        return urlsList;
-    }
-
     public static string GetClientIP(HttpContext context) => context?.Connection.RemoteIpAddress?.ToString();
 
     public static string TryGetFullOSVersion()
@@ -108,49 +67,6 @@ public static class Helper
         }
 
         return osVer.VersionString;
-    }
-
-    public static string GetDNSPrefetchUrl(string cdnEndpoint)
-    {
-        if (string.IsNullOrWhiteSpace(cdnEndpoint)) return string.Empty;
-
-        var uri = new Uri(cdnEndpoint);
-        return $"{uri.Scheme}://{uri.Host}/";
-    }
-
-    public static string ResolveRootUrl(HttpContext ctx, string canonicalPrefix, bool preferCanonical = false, bool removeTailSlash = false)
-    {
-        if (ctx is null && !preferCanonical)
-        {
-            throw new ArgumentNullException(nameof(ctx), "HttpContext must not be null when preferCanonical is 'false'");
-        }
-
-        var url = preferCanonical ?
-            ResolveCanonicalUrl(canonicalPrefix, string.Empty) :
-            $"{ctx.Request.Scheme}://{ctx.Request.Host}";
-
-        if (removeTailSlash && url.EndsWith('/'))
-        {
-            return url.TrimEnd('/');
-        }
-
-        return url;
-    }
-
-    public static string ResolveCanonicalUrl(string prefix, string path)
-    {
-        if (string.IsNullOrWhiteSpace(prefix)) return string.Empty;
-        path ??= string.Empty;
-
-        if (!prefix.IsValidUrl())
-        {
-            throw new UriFormatException($"Prefix '{prefix}' is not a valid URL.");
-        }
-
-        var prefixUri = new Uri(prefix);
-        return Uri.TryCreate(baseUri: prefixUri, relativeUri: path, out var newUri) ?
-            newUri.ToString() :
-            string.Empty;
     }
 
     public static string FormatCopyright2Html(string copyrightCode)
@@ -283,14 +199,4 @@ public static class Helper
 
     public static string GetMagic(int value, int start, int end) =>
         Convert.ToBase64String(SHA256.HashData(BitConverter.GetBytes(value)))[start..end];
-
-    public static string GenerateRouteLink(DateTime publishDate, string slug)
-    {
-        if (string.IsNullOrWhiteSpace(slug))
-        {
-            throw new ArgumentNullException(nameof(slug), "Slug must not be null or empty.");
-        }
-
-        return $"{publishDate.ToString("yyyy/M/d", CultureInfo.InvariantCulture)}/{slug.ToLower()}";
-    }
 }

--- a/src/Moonglade.Utils/SecurityHelper.cs
+++ b/src/Moonglade.Utils/SecurityHelper.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using System.Net;
+using System.Security.Cryptography;
+
+namespace Moonglade.Utils;
+
+public static class SecurityHelper
+{
+    // https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/consumer-apis/password-hashing?view=aspnetcore-6.0
+    // This is not secure, but better than nothing.
+    public static string HashPassword(string clearPassword, string saltBase64)
+    {
+        var salt = Convert.FromBase64String(saltBase64);
+
+        // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
+        string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+            password: clearPassword!,
+            salt: salt,
+            prf: KeyDerivationPrf.HMACSHA256,
+            iterationCount: 100000,
+            numBytesRequested: 256 / 8));
+
+        return hashed;
+    }
+
+    public static string GenerateSalt()
+    {
+        // Generate a 128-bit salt using a sequence of cryptographically strong random bytes.
+        byte[] salt = RandomNumberGenerator.GetBytes(128 / 8); // divide by 8 to convert bits to bytes
+        return Convert.ToBase64String(salt);
+    }
+
+    public static string SterilizeLink(string rawUrl)
+    {
+        bool IsUnderLocalSlash()
+        {
+            // Allows "/" or "/foo" but not "//" or "/\".
+            if (rawUrl[0] == '/')
+            {
+                // url is exactly "/"
+                if (rawUrl.Length == 1)
+                {
+                    return true;
+                }
+
+                // url doesn't start with "//" or "/\"
+                return rawUrl[1] is not '/' and not '\\';
+            }
+
+            return false;
+        }
+
+        string invalidReturn = "#";
+        if (string.IsNullOrWhiteSpace(rawUrl))
+        {
+            return invalidReturn;
+        }
+
+        if (!rawUrl.IsValidUrl())
+        {
+            return IsUnderLocalSlash() ? rawUrl : invalidReturn;
+        }
+
+        var uri = new Uri(rawUrl);
+        if (uri.IsLoopback)
+        {
+            // localhost, 127.0.0.1
+            return invalidReturn;
+        }
+
+        if (uri.HostNameType == UriHostNameType.IPv4)
+        {
+            // Disallow LAN IP (e.g. 192.168.0.1, 10.0.0.1)
+            if (IsPrivateIP(uri.Host))
+            {
+                return invalidReturn;
+            }
+        }
+
+        return rawUrl;
+    }
+
+    /// <summary>
+    /// Test an IPv4 address is LAN or not.
+    /// </summary>
+    /// <param name="ip">IPv4 address</param>
+    /// <returns>bool</returns>
+    public static bool IsPrivateIP(string ip) => IPAddress.Parse(ip).GetAddressBytes() switch
+    {
+        // Regex.IsMatch(ip, @"(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)")
+        // Regex has bad performance, this is better
+
+        var x when x[0] is 192 && x[1] is 168 => true,
+        var x when x[0] is 10 => true,
+        var x when x[0] is 127 => true,
+        var x when x[0] is 172 && x[1] is >= 16 and <= 31 => true,
+        _ => false
+    };
+
+}

--- a/src/Moonglade.Utils/UrlHelper.cs
+++ b/src/Moonglade.Utils/UrlHelper.cs
@@ -114,6 +114,12 @@ public static class UrlHelper
         if (string.IsNullOrWhiteSpace(prefix)) return string.Empty;
         path ??= string.Empty;
 
+        // Check if path contains space or invalid characters
+        if (path.IndexOfAny([' ', '\t', '\n', '\r']) >= 0 || path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+        {
+            return string.Empty;
+        }
+
         if (!prefix.IsValidUrl())
         {
             throw new UriFormatException($"Prefix '{prefix}' is not a valid URL.");

--- a/src/Moonglade.Utils/UrlHelper.cs
+++ b/src/Moonglade.Utils/UrlHelper.cs
@@ -20,6 +20,17 @@ public static class UrlHelper
         string dd = match.Groups["dd"].Value;
         string slug = match.Groups["slug"].Value;
 
+        // validate month and day
+        if (!int.TryParse(mm, out int month) || month < 1 || month > 12)
+        {
+            throw new FormatException("Invalid Slug Format");
+        }
+
+        if (!int.TryParse(dd, out int day) || day < 1 || day > DateTime.DaysInMonth(int.Parse(yyyy), month))
+        {
+            throw new FormatException("Invalid Slug Format");
+        }
+
         return $"{yyyy}/{mm}/{dd}/{slug}".ToLower();
     }
 

--- a/src/Moonglade.Utils/UrlHelper.cs
+++ b/src/Moonglade.Utils/UrlHelper.cs
@@ -39,7 +39,10 @@ public static class UrlHelper
         {
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
-                urlsList.Add(uri);
+                if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+                {
+                    urlsList.Add(uri);
+                }
             }
         }
 
@@ -61,6 +64,18 @@ public static class UrlHelper
         if (string.IsNullOrWhiteSpace(cdnEndpoint)) return string.Empty;
 
         var uri = new Uri(cdnEndpoint);
+
+        if (!uri.IsAbsoluteUri || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return string.Empty;
+        }
+
+        if (uri.Scheme == Uri.UriSchemeHttp && uri.Port != 80 ||
+            uri.Scheme == Uri.UriSchemeHttps && uri.Port != 443)
+        {
+            return $"{uri.Scheme}://{uri.Host}:{uri.Port}/";
+        }
+
         return $"{uri.Scheme}://{uri.Host}/";
     }
 

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -139,7 +139,7 @@ public class CommentController(
 
     private string GetPostUrl(string routeLink)
     {
-        var baseUri = new Uri(Helper.ResolveRootUrl(HttpContext, null, removeTailSlash: true));
+        var baseUri = new Uri(UrlHelper.ResolveRootUrl(HttpContext, null, removeTailSlash: true));
         var link = new Uri(baseUri, $"post/{routeLink.ToLower()}");
         return link.ToString();
     }

--- a/src/Moonglade.Web/Controllers/PostController.cs
+++ b/src/Moonglade.Web/Controllers/PostController.cs
@@ -84,7 +84,7 @@ public class PostController(
 
             logger.LogInformation("Trying to Ping URL for post: {Id}", postEntity.Id);
 
-            var baseUri = new Uri(Helper.ResolveRootUrl(HttpContext, null, removeTailSlash: true));
+            var baseUri = new Uri(UrlHelper.ResolveRootUrl(HttpContext, null, removeTailSlash: true));
             var link = new Uri(baseUri, $"post/{postEntity.RouteLink.ToLower()}");
 
             NotifyExternalServices(postEntity.PostContent, link);

--- a/src/Moonglade.Web/Controllers/SettingsController.cs
+++ b/src/Moonglade.Web/Controllers/SettingsController.cs
@@ -213,7 +213,7 @@ public class SettingsController(
             }
 
             // Sterilize
-            link.Url = Helper.SterilizeLink(link.Url);
+            link.Url = SecurityHelper.SterilizeLink(link.Url);
         }
 
         blogConfig.SocialLinkSettings = new()
@@ -285,14 +285,14 @@ public class SettingsController(
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UpdateLocalAccountPassword(UpdateLocalAccountPasswordRequest request)
     {
-        var oldPasswordValid = blogConfig.LocalAccountSettings.PasswordHash == Helper.HashPassword(request.OldPassword.Trim(), blogConfig.LocalAccountSettings.PasswordSalt);
+        var oldPasswordValid = blogConfig.LocalAccountSettings.PasswordHash == SecurityHelper.HashPassword(request.OldPassword.Trim(), blogConfig.LocalAccountSettings.PasswordSalt);
 
         if (!oldPasswordValid) return Conflict("Old password is incorrect.");
 
-        var newSalt = Helper.GenerateSalt();
+        var newSalt = SecurityHelper.GenerateSalt();
         blogConfig.LocalAccountSettings.Username = request.NewUsername.Trim();
         blogConfig.LocalAccountSettings.PasswordSalt = newSalt;
-        blogConfig.LocalAccountSettings.PasswordHash = Helper.HashPassword(request.NewPassword, newSalt);
+        blogConfig.LocalAccountSettings.PasswordHash = SecurityHelper.HashPassword(request.NewPassword, newSalt);
 
         await SaveConfigAsync(blogConfig.LocalAccountSettings);
         return NoContent();

--- a/src/Moonglade.Web/Controllers/SubscriptionController.cs
+++ b/src/Moonglade.Web/Controllers/SubscriptionController.cs
@@ -18,7 +18,7 @@ public class SubscriptionController(
 
         var cats = await queryMediator.QueryAsync(new GetCategoriesQuery());
         var catInfos = cats.Select(c => new KeyValuePair<string, string>(c.DisplayName, c.Slug));
-        var rootUrl = Helper.ResolveRootUrl(HttpContext, blogConfig.GeneralSettings.CanonicalPrefix);
+        var rootUrl = UrlHelper.ResolveRootUrl(HttpContext, blogConfig.GeneralSettings.CanonicalPrefix);
 
         var oi = new OpmlDoc
         {

--- a/src/Moonglade.Web/Handlers/FoafMapHandler.cs
+++ b/src/Moonglade.Web/Handlers/FoafMapHandler.cs
@@ -24,7 +24,7 @@ public class FoafMapHandler
 
             var foafDoc = new FoafDoc(
                 Name: general.OwnerName,
-                BlogUrl: Helper.ResolveRootUrl(httpContext, general.CanonicalPrefix, preferCanonical: true),
+                BlogUrl: UrlHelper.ResolveRootUrl(httpContext, general.CanonicalPrefix, preferCanonical: true),
                 Email: general.OwnerEmail,
                 PhotoUrl: linkGenerator.GetUriByAction(httpContext, "Avatar", "Assets") ?? string.Empty
             );

--- a/src/Moonglade.Web/Handlers/SiteMapMapHandler.cs
+++ b/src/Moonglade.Web/Handlers/SiteMapMapHandler.cs
@@ -26,7 +26,7 @@ public class SiteMapMapHandler
     {
         var xml = await cache.GetOrCreateAsync(BlogCachePartition.General.ToString(), "sitemap", async _ =>
         {
-            var url = Helper.ResolveRootUrl(httpContext, blogConfig.GeneralSettings.CanonicalPrefix, true, true);
+            var url = UrlHelper.ResolveRootUrl(httpContext, blogConfig.GeneralSettings.CanonicalPrefix, true, true);
             var data = await GetSiteMapData(url, postRepo, pageRepo, httpContext.RequestAborted);
             return data;
         });

--- a/src/Moonglade.Web/Middleware/OpenSearchMiddleware.cs
+++ b/src/Moonglade.Web/Middleware/OpenSearchMiddleware.cs
@@ -10,7 +10,7 @@ public class OpenSearchMiddleware(RequestDelegate next)
     {
         if (httpContext.Request.Path == Options.RequestPath && blogConfig.AdvancedSettings.EnableOpenSearch)
         {
-            var siteRootUrl = Helper.ResolveRootUrl(httpContext, blogConfig.GeneralSettings.CanonicalPrefix, true);
+            var siteRootUrl = UrlHelper.ResolveRootUrl(httpContext, blogConfig.GeneralSettings.CanonicalPrefix, true);
             var xml = await GetOpenSearchData(siteRootUrl, blogConfig.GeneralSettings.SiteTitle, blogConfig.GeneralSettings.Description);
 
             httpContext.Response.ContentType = "text/xml";

--- a/src/Moonglade.Web/Pages/Admin/PostPreview.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/PostPreview.cshtml
@@ -49,7 +49,7 @@
     @if (!string.IsNullOrWhiteSpace(Post.HeroImageUrl))
     {
         <div class="post-hero-image-container text-center mb-3">
-            <img src="@Helper.SterilizeLink(Post.HeroImageUrl)" class="post-hero-image img-fluid rounded-3 shadow-sm" />
+            <img src="@SecurityHelper.SterilizeLink(Post.HeroImageUrl)" class="post-hero-image img-fluid rounded-3 shadow-sm" />
         </div>
     }
 

--- a/src/Moonglade.Web/Pages/Components/FriendLink/Default.cshtml
+++ b/src/Moonglade.Web/Pages/Components/FriendLink/Default.cshtml
@@ -9,7 +9,7 @@
         <div role="list">
             @foreach (var item in Model.OrderBy(c => c.Rank).ThenBy(c => c.Title))
             {
-                <a href="@Helper.SterilizeLink(item.LinkUrl)" target="_blank" class="d-block mb-3 mt-2" role="listitem">
+                <a href="@SecurityHelper.SterilizeLink(item.LinkUrl)" target="_blank" class="d-block mb-3 mt-2" role="listitem">
                     <i class="bi-link-45deg me-1"></i>
                     @item.Title
                 </a>

--- a/src/Moonglade.Web/Pages/Components/Menu/Default.cshtml
+++ b/src/Moonglade.Web/Pages/Components/Menu/Default.cshtml
@@ -8,7 +8,7 @@
         if (menuModel.SubMenus.Count == 0)
         {
             <li class="nav-item">
-                <a href="@Helper.SterilizeLink(menuModel.Url)"
+                <a href="@SecurityHelper.SterilizeLink(menuModel.Url)"
                    class="nav-link"
                    target="@(menuModel.IsOpenInNewTab ? "_blank" : null)">
                     <span class="@menuModel.Icon d-lg-none d-xl-inline-block"></span>
@@ -28,7 +28,7 @@
                     {
                         <li>
                             <a class="dropdown-item"
-                               href="@Helper.SterilizeLink(subMenu.Url)"
+                               href="@SecurityHelper.SterilizeLink(subMenu.Url)"
                                target="@(subMenu.IsOpenInNewTab ? "_blank" : null)">
                                 <span class="bi-link-45deg"></span>
                                 @subMenu.Title

--- a/src/Moonglade.Web/Pages/Components/SocialLink/Default.cshtml
+++ b/src/Moonglade.Web/Pages/Components/SocialLink/Default.cshtml
@@ -9,7 +9,7 @@
         <div role="list">
             @foreach (var item in Model.OrderBy(c => c.Name))
             {
-                <a href="@Helper.SterilizeLink(item.Url)" target="_blank" class="d-block mb-3 mt-2" role="listitem">
+                <a href="@SecurityHelper.SterilizeLink(item.Url)" target="_blank" class="d-block mb-3 mt-2" role="listitem">
                     <i class="@item.Icon me-1"></i>
                     @item.Name
                 </a>

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -135,7 +135,7 @@
     @if (!string.IsNullOrWhiteSpace(Model.Post.HeroImageUrl))
     {
         <div class="post-hero-image-container text-center mb-3">
-            <img src="@Helper.SterilizeLink(Model.Post.HeroImageUrl)" class="post-hero-image img-fluid rounded-3 shadow-sm" />
+            <img src="@SecurityHelper.SterilizeLink(Model.Post.HeroImageUrl)" class="post-hero-image img-fluid rounded-3 shadow-sm" />
         </div>
     }
 

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -40,7 +40,7 @@
 
     @if (BlogConfig.AdvancedSettings.EnableWebmention)
     {
-        <link rel="webmention" href="@(Helper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, "webmention"))">
+        <link rel="webmention" href="@(UrlHelper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, "webmention"))">
     }
 }
 
@@ -60,7 +60,7 @@
     <meta property="og:description" content="@Model.Post.ContentAbstract" />
     @if (!string.IsNullOrWhiteSpace(BlogConfig.GeneralSettings.CanonicalPrefix))
     {
-        <meta property="og:url" content="@(Helper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, HttpContext.Request.Path))" />
+        <meta property="og:url" content="@(UrlHelper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, HttpContext.Request.Path))" />
     }
 }
 

--- a/src/Moonglade.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Moonglade.Web/Pages/Shared/_Layout.cshtml
@@ -63,12 +63,12 @@
     @if (BlogConfig.ImageSettings.EnableCDNRedirect &&
         !string.IsNullOrWhiteSpace(BlogConfig.ImageSettings.CDNEndpoint))
     {
-        <link rel="dns-prefetch" href="@Helper.GetDNSPrefetchUrl(BlogConfig.ImageSettings.CDNEndpoint)" />
+        <link rel="dns-prefetch" href="@UrlHelper.GetDNSPrefetchUrl(BlogConfig.ImageSettings.CDNEndpoint)" />
     }
 
     @if (!string.IsNullOrWhiteSpace(BlogConfig.GeneralSettings.CanonicalPrefix))
     {
-        <link rel="canonical" href="@(Helper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, Context.Request.Path))" />
+        <link rel="canonical" href="@(UrlHelper.ResolveCanonicalUrl(BlogConfig.GeneralSettings.CanonicalPrefix, Context.Request.Path))" />
     }
 
     <link rel="start" title="@BlogConfig.GeneralSettings.SiteTitle" href="~/" />

--- a/src/Moonglade.Webmention/ReceiveWebmentionCommand.cs
+++ b/src/Moonglade.Webmention/ReceiveWebmentionCommand.cs
@@ -52,7 +52,7 @@ public class ReceiveWebmentionCommandHandler(
                 return WebmentionResponse.SpamDetectedFakeNotFound;
             }
 
-            var routeLink = Helper.GetRouteLinkFromUrl(mentionRequest.TargetUrl);
+            var routeLink = UrlHelper.GetRouteLinkFromUrl(mentionRequest.TargetUrl);
             var spec = new PostByRouteLinkForIdTitleSpec(routeLink);
             var (id, title) = await postRepo.FirstOrDefaultAsync(spec, ct);
             if (id == Guid.Empty)

--- a/src/Moonglade.Webmention/WebmentionSender.cs
+++ b/src/Moonglade.Webmention/WebmentionSender.cs
@@ -26,7 +26,7 @@ public class WebmentionSender(
             {
                 logger.LogInformation("URL is detected in post content, trying to send webmention requests.");
 
-                foreach (var url in Helper.GetUrlsFromContent(postContent))
+                foreach (var url in UrlHelper.GetUrlsFromContent(postContent))
                 {
                     if (url.IsLocalhostUrl())
                     {


### PR DESCRIPTION
This pull request refactors several utility methods by moving security-related and URL-handling logic out of the `Helper` class into new, more appropriately named helper classes (`SecurityHelper` and `UrlHelper`). It also updates code throughout the project to use these new helpers, and makes some minor improvements to tag normalization and validation. Additionally, there are small changes to test code regarding nullable reference types.

Refactoring and code organization:

* Extracted password hashing and link sterilization logic from `Helper` into a new `SecurityHelper` class, and updated all usages to reference `SecurityHelper` instead. (`SecurityHelper.HashPassword`, `SecurityHelper.SterilizeLink`, etc.) [[1]](diffhunk://#diff-7d9d774659a95f62b05e4ed57c39b36c779d8224401018b551a32e64ca7cfb20L22-R22) [[2]](diffhunk://#diff-cb52d3357c67e657131204a8dac468bd3d221f81a1ba692349cdb3ab48e121f7L58-R62) [[3]](diffhunk://#diff-343ff1373423d249fa800cb1bd8c5172969d3c48d2c5bc00267f775efb73b247L125-R127) [[4]](diffhunk://#diff-a021265e9d878b406e1271dfa5aaf180d7582223ffe2780cf397627209574c83L46-R46) [[5]](diffhunk://#diff-1aec3210078ea3a2a9aa83b8e60a4c608400ff0c2c796da7c7b777481c2763c9L26-R26) [[6]](diffhunk://#diff-abac9524314131921f8e11ec34147e7ef8c1576f7ae93c5bd14d1533f135cfe6R1-R100) [[7]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L115-L248)
* Moved route link generation and URL extraction logic from `Helper` to a new `UrlHelper` class, and updated all usages to reference `UrlHelper` instead. (`UrlHelper.GenerateRouteLink`, `UrlHelper.GetRouteLinkFromUrl`, `UrlHelper.GetUrlsFromContent`) [[1]](diffhunk://#diff-cb52d3357c67e657131204a8dac468bd3d221f81a1ba692349cdb3ab48e121f7L58-R62) [[2]](diffhunk://#diff-61729ff4eaebbfb1013b431c7cb02801302ba7de966425b6be62c1a9c611d128L28-R28) [[3]](diffhunk://#diff-f32609ce3d4853a41af5546b7e3f4c02af09804d049453d30aead988dcec5340L28-R28) [[4]](diffhunk://#diff-343ff1373423d249fa800cb1bd8c5172969d3c48d2c5bc00267f775efb73b247L125-R127) [[5]](diffhunk://#diff-d789144574f0d1904ef36414902f55070cf04aed0c787ffb847eb9e226ce5c05L28-R28) [[6]](diffhunk://#diff-e2b50067b0089bcf8b69f45af3965e8d948530570b9820668cba084186233eaaL58-R58) [[7]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L47-L86) [[8]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L379-L388)

Improvements to tag handling:

* Improved `.net` tag normalization to handle cases where the tag starts with `.net` and to replace all occurrences, not just exact matches.
* Updated the regular expression for validating Chinese tag names to ensure the entire string consists of CJK Unified Ideographs.

Test and code quality adjustments:

* Removed the `<Nullable>enable</Nullable>` property from the test project, and updated test method signatures to use non-nullable reference types for parameters. [[1]](diffhunk://#diff-63c95e2287ed0b7720c8669fd6dc728317ff3610116075fa2bf6a163460ded39L6-L7) [[2]](diffhunk://#diff-8ca11c4ce15f776def70bcb6b110324b6644a952c77e4030e30fa69cb45d3d24L45-R45) [[3]](diffhunk://#diff-8ca11c4ce15f776def70bcb6b110324b6644a952c77e4030e30fa69cb45d3d24L108-R108)

Cleanup:

* Removed unused or relocated methods from the `Helper` class, such as password hashing, salt generation, link sterilization, route link generation, and URL extraction. [[1]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L47-L86) [[2]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L115-L248) [[3]](diffhunk://#diff-0cd4240dc2e5b55695463f054bf8a6ff2270b90cecae248ea81ecc3db6460c19L379-L388)