### PR TITLE
Tags admin improvements

### DIFF
--- a/src/Moonglade.Web/Pages/Admin/Tags.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/Tags.cshtml
@@ -1,9 +1,8 @@
 ﻿@page "/admin/tags"
 @using Moonglade.Core.TagFeature
+@using Moonglade.Data.Entities
 @{
     ViewBag.Title = "Tags";
-    var tags = await QueryMediator.QueryAsync(new GetTagCountListQuery());
-    var sortedTags = tags.OrderBy(t => t.Tag.DisplayName).ToList();
 }
 
 @Html.AntiForgeryToken()
@@ -28,52 +27,154 @@
 }
 
 <div>
-    <input id="tagFilter" type="text" class="form-control mb-3" maxlength="32" placeholder="@SharedLocalizer["Filter"]">
+    <input id="tagFilter"
+           type="text"
+           class="form-control mb-3"
+           maxlength="32"
+           placeholder="@SharedLocalizer["Filter"]"
+           aria-label="@SharedLocalizer["Filter tags"]">
 
-    <h4>Active tags</h4>
-    <hr />
-    <ul class="list-unstyled ul-tag-mgr">
-        @foreach (var tagItem in sortedTags.Where(p => p.PostCount > 0))
-        {
-            <li id="li-tag-@tagItem.Tag.Id" class="admin-tag-item border rounded">
-                <span class="span-tagcontent-editable" contenteditable="true" spellcheck="false" data-tagid="@tagItem.Tag.Id">@tagItem.Tag.DisplayName</span>
-                <a class="btn-delete" data-tagid="@tagItem.Tag.Id">
-                    <i class="bi-trash"></i>
-                </a>
-            </li>
-        }
-    </ul>
+    @if (TagCountList?.Count > 0)
+    {
+        var activeTags = TagCountList.Where(p => p.PostCount > 0).OrderBy(t => t.Tag.DisplayName).ToList();
+        var inactiveTags = TagCountList.Where(p => p.PostCount == 0).OrderBy(t => t.Tag.DisplayName).ToList();
 
-    <h4>Tags with zero posts</h4>
-    <hr />
-    <ul class="list-unstyled ul-tag-mgr">
-        @foreach (var tagItem in sortedTags.Where(p => p.PostCount == 0))
-        {
-            <li id="li-tag-@tagItem.Tag.Id" class="admin-tag-item border rounded">
-                <span class="span-tagcontent-editable" contenteditable="true" spellcheck="false" data-tagid="@tagItem.Tag.Id">@tagItem.Tag.DisplayName</span>
-                <a class="btn-delete" data-tagid="@tagItem.Tag.Id">
-                    <i class="bi-trash"></i>
-                </a>
-            </li>
-        }
-    </ul>
+        <section aria-labelledby="active-tags-heading">
+            <h4 id="active-tags-heading">@SharedLocalizer["Active tags"]</h4>
+            <hr />
+            @if (activeTags.Any())
+            {
+                <ul class="list-unstyled ul-tag-mgr" role="list">
+                    @foreach (var tagItem in activeTags)
+                    {
+                        <li id="li-tag-@tagItem.Tag.Id" class="admin-tag-item border rounded">
+                            <span class="span-tagcontent-editable"
+                                  contenteditable="true"
+                                  spellcheck="false"
+                                  data-tagid="@tagItem.Tag.Id"
+                                  aria-label="@string.Format(SharedLocalizer["Edit tag {0}"], tagItem.Tag.DisplayName)">
+                                @tagItem.Tag.DisplayName
+                            </span>
+                            <span class="tag-postcount"
+                                  title="@string.Format(SharedLocalizer["{0} posts"], tagItem.PostCount)">
+                                @tagItem.PostCount
+                            </span>
+                            <a class="btn-delete"
+                                    data-tagid="@tagItem.Tag.Id"
+                                    aria-label="@string.Format(SharedLocalizer["Delete tag {0}"], tagItem.Tag.DisplayName)"
+                                    title="@SharedLocalizer["Delete tag"]">
+                                <i class="bi-trash"></i>
+                            </a>
+                        </li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <div class="alert alert-info" role="alert">
+                    @SharedLocalizer["No active tags found"]
+                </div>
+            }
+        </section>
+
+        <section aria-labelledby="inactive-tags-heading" class="mt-4">
+            <h4 id="inactive-tags-heading">@SharedLocalizer["Tags without posts"]</h4>
+            <hr />
+            @if (inactiveTags.Any())
+            {
+                <ul class="list-unstyled ul-tag-mgr" role="list">
+                    @foreach (var tagItem in inactiveTags)
+                    {
+                        <li id="li-tag-@tagItem.Tag.Id" class="admin-tag-item border rounded opacity-75">
+                            <span class="span-tagcontent-editable"
+                                  contenteditable="true"
+                                  spellcheck="false"
+                                  data-tagid="@tagItem.Tag.Id"
+                                  aria-label="@string.Format(SharedLocalizer["Edit tag {0}"], tagItem.Tag.DisplayName)">
+                                @tagItem.Tag.DisplayName
+                            </span>
+                            <a class="btn-delete"
+                                    data-tagid="@tagItem.Tag.Id"
+                                    aria-label="@string.Format(SharedLocalizer["Delete tag {0}"], tagItem.Tag.DisplayName)"
+                                    title="@SharedLocalizer["Delete tag"]">
+                                <i class="bi-trash"></i>
+                            </a>
+                        </li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <div class="alert alert-success" role="alert">
+                    @SharedLocalizer["No unused tags - all tags are being used!"]
+                </div>
+            }
+        </section>
+    }
+    else
+    {
+        <div class="alert alert-info" role="alert">
+            @SharedLocalizer["No tags found. Create your first tag to get started."]
+        </div>
+    }
 </div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="editTagCanvas" aria-labelledby="editTagCanvasLabel">
     <div class="offcanvas-header">
         <h5 class="offcanvas-title" id="editTagCanvasLabel">@SharedLocalizer["Create Tag"]</h5>
-        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="@SharedLocalizer["Close"]"></button>
     </div>
     <div class="offcanvas-body">
-        <form id="edit-form" method="post">
-            <div class="mb-2">
-                <label class="form-label">@SharedLocalizer["Name"]</label>
-                <input type="text" name="tagName" id="input-tag-name" class="form-control" required />
+        <form id="edit-form" method="post" novalidate>
+            <div class="mb-3">
+                <label for="input-tag-name" class="form-label">
+                    @SharedLocalizer["Name"] <span class="text-danger">*</span>
+                </label>
+                <input type="text"
+                       name="tagName"
+                       id="input-tag-name"
+                       class="form-control"
+                       required
+                       maxlength="50"
+                       aria-describedby="tag-name-help"
+                       placeholder="@SharedLocalizer["Enter tag name"]" />
+                <div id="tag-name-help" class="form-text">
+                    @SharedLocalizer["Tag names should be descriptive and concise."]
+                </div>
+                <div class="invalid-feedback">
+                    @SharedLocalizer["Please provide a valid tag name."]
+                </div>
             </div>
-            <div class="mt-3">
-                <button type="submit" class="btn btn-outline-accent">@SharedLocalizer["Submit"]</button>
-                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">@SharedLocalizer["Cancel"]</button>
+            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">
+                    @SharedLocalizer["Cancel"]
+                </button>
+                <button type="submit" class="btn btn-outline-accent">
+                    <i class="bi-check-lg"></i>
+                    @SharedLocalizer["Submit"]
+                </button>
             </div>
         </form>
     </div>
 </div>
+
+@functions
+{
+    public List<(TagEntity Tag, int PostCount)> TagCountList { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        try
+        {
+            var tags = await QueryMediator.QueryAsync(new GetTagCountListQuery());
+            TagCountList = tags?.ToList() ?? new List<(TagEntity Tag, int PostCount)>();
+            return Page();
+        }
+        catch (Exception)
+        {
+            // Log exception here
+            ModelState.AddModelError(string.Empty, SharedLocalizer["An error occurred while loading tags."]);
+            return Page();
+        }
+    }
+}

--- a/src/Moonglade.Web/wwwroot/css/admin.css
+++ b/src/Moonglade.Web/wwwroot/css/admin.css
@@ -214,7 +214,7 @@ div.mce-fullscreen {
     }
 }
 
-.ul-tag-mgr li span {
+.ul-tag-mgr li span.span-tagcontent-editable {
     display: inline-block;
     padding: 0 10px;
     vertical-align: top;
@@ -234,6 +234,13 @@ div.mce-fullscreen {
         background-color: var(--bs-red);
         color: var(--bs-white);
     }
+
+.ul-tag-mgr .tag-postcount {
+    border-left: 1px solid var(--bs-gray-400);
+    padding: 0 5px;
+    text-align: center;
+    color: var(--bs-secondary);
+}
 
 .table .table-item-w10 {
     width: 10%;


### PR DESCRIPTION
This pull request refactors the admin tags page to improve accessibility, user experience, and maintainability. The changes include a clearer separation of active and inactive tags, enhanced accessibility attributes for form controls and interactive elements, improved form validation and feedback, and UI updates to display post counts for tags. Additionally, backend logic is moved to page functions for better organization.

**UI/UX Improvements:**
* The tags list is now split into "Active tags" and "Tags without posts" sections, making it easier to distinguish between tags in use and unused tags. Each section displays appropriate alerts when empty. (`src/Moonglade.Web/Pages/Admin/Tags.cshtml` [src/Moonglade.Web/Pages/Admin/Tags.cshtmlL31-R180](diffhunk://#diff-40cafc449a555186ad471be9ffd632cd0fd21672c98d35ec503a8640c6267762L31-R180))
* The tag filter input, tag edit controls, and delete buttons now include accessibility attributes such as `aria-label` and descriptive placeholders, improving usability for screen readers. (`src/Moonglade.Web/Pages/Admin/Tags.cshtml` [src/Moonglade.Web/Pages/Admin/Tags.cshtmlL31-R180](diffhunk://#diff-40cafc449a555186ad471be9ffd632cd0fd21672c98d35ec503a8640c6267762L31-R180))
* The tag creation/edit form now provides validation feedback, a help text, and improved layout, ensuring users receive clear guidance and error messages when entering tag names. (`src/Moonglade.Web/Pages/Admin/Tags.cshtml` [src/Moonglade.Web/Pages/Admin/Tags.cshtmlL31-R180](diffhunk://#diff-40cafc449a555186ad471be9ffd632cd0fd21672c98d35ec503a8640c6267762L31-R180))

**Backend and Code Organization:**
* The logic for loading and categorizing tags is moved into page functions (`OnGetAsync` and `TagCountList` property), improving maintainability and separating concerns between view and data fetching. (`src/Moonglade.Web/Pages/Admin/Tags.cshtml` [src/Moonglade.Web/Pages/Admin/Tags.cshtmlL31-R180](diffhunk://#diff-40cafc449a555186ad471be9ffd632cd0fd21672c98d35ec503a8640c6267762L31-R180))

**Styling Updates:**
* Added a new `.tag-postcount` CSS class to style the post count display next to each tag, visually distinguishing the number of posts per tag. (`src/Moonglade.Web/wwwroot/css/admin.css` [src/Moonglade.Web/wwwroot/css/admin.cssR238-R244](diffhunk://#diff-59831601d5d1268a2b21181a433a565d7e9a1b4df878f7a728f4cad1ce4b57c1R238-R244))
* Updated selector for tag content editing spans to be more specific, preventing unintended styling conflicts. (`src/Moonglade.Web/wwwroot/css/admin.css` [src/Moonglade.Web/wwwroot/css/admin.cssL217-R217](diffhunk://#diff-59831601d5d1268a2b21181a433a565d7e9a1b4df878f7a728f4cad1ce4b57c1L217-R217))