### PR TITLE
Allow manually set keywords for blog posts

### DIFF
--- a/Deployment/mssql-migration.sql
+++ b/Deployment/mssql-migration.sql
@@ -130,3 +130,15 @@ BEGIN
     ALTER TABLE dbo.Post ADD ScheduledPublishTimeUtc DATETIME NULL;
 END
 GO
+
+-- v14.28
+IF NOT EXISTS (
+    SELECT 1 
+    FROM sys.columns 
+    WHERE object_id = OBJECT_ID('dbo.Post') 
+      AND name = 'Keywords'
+)
+BEGIN
+    ALTER TABLE dbo.Post ADD Keywords NVARCHAR(256) NULL;
+END
+GO

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -60,6 +60,7 @@ public class CreatePostCommandHandler(
         };
 
         post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), request.Payload.Slug);
+        post.Keywords = GetKeywords(request.Payload.Keywords);
 
         await CheckSlugConflict(post, ct);
 
@@ -130,5 +131,20 @@ public class CreatePostCommandHandler(
 
         logger.LogInformation($"Created tag: {tag.DisplayName}");
         return tag;
+    }
+
+    private static string GetKeywords(string rawKeywords)
+    {
+        if (string.IsNullOrWhiteSpace(rawKeywords)) return null;
+
+        var keywords = rawKeywords.Split(',')
+            .Select(k => k.Trim())
+            .Where(k => !string.IsNullOrWhiteSpace(k))
+            .Distinct()
+            .ToArray();
+
+        if (keywords.Length == 0) return null;
+
+        return string.Join(',', keywords);
     }
 }

--- a/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/CreatePostCommand.cs
@@ -60,7 +60,7 @@ public class CreatePostCommandHandler(
         };
 
         post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), request.Payload.Slug);
-        post.Keywords = GetKeywords(request.Payload.Keywords);
+        post.Keywords = ContentProcessor.GetKeywords(request.Payload.Keywords);
 
         await CheckSlugConflict(post, ct);
 
@@ -131,20 +131,5 @@ public class CreatePostCommandHandler(
 
         logger.LogInformation($"Created tag: {tag.DisplayName}");
         return tag;
-    }
-
-    private static string GetKeywords(string rawKeywords)
-    {
-        if (string.IsNullOrWhiteSpace(rawKeywords)) return null;
-
-        var keywords = rawKeywords.Split(',')
-            .Select(k => k.Trim())
-            .Where(k => !string.IsNullOrWhiteSpace(k))
-            .Distinct()
-            .ToArray();
-
-        if (keywords.Length == 0) return null;
-
-        return string.Join(',', keywords);
     }
 }

--- a/src/Moonglade.Core/PostFeature/PostEditModel.cs
+++ b/src/Moonglade.Core/PostFeature/PostEditModel.cs
@@ -53,6 +53,7 @@ public class PostEditModel
     public string Abstract { get; set; }
 
     [MaxLength(256)]
+    [Display(Name = "Keywords (split by comma ',')")]
     public string Keywords { get; set; }
 
     [Display(Name = "Publish Date")]

--- a/src/Moonglade.Core/PostFeature/PostEditModel.cs
+++ b/src/Moonglade.Core/PostFeature/PostEditModel.cs
@@ -52,6 +52,9 @@ public class PostEditModel
     [MaxLength(1024)]
     public string Abstract { get; set; }
 
+    [MaxLength(256)]
+    public string Keywords { get; set; }
+
     [Display(Name = "Publish Date")]
     [DataType(DataType.Date)]
     public DateTime? PublishDate { get; set; }

--- a/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
+++ b/src/Moonglade.Core/PostFeature/UpdatePostCommand.cs
@@ -27,7 +27,7 @@ public class UpdatePostCommandHandler(
         UpdatePostDetails(post, postEditModel, utcNow);
 
         await UpdateTags(post, postEditModel.Tags, ct);
-        UpdateCats(post, postEditModel.SelectedCatIds, ct);
+        UpdateCats(post, postEditModel.SelectedCatIds);
 
         await postRepo.UpdateAsync(post, ct);
 
@@ -125,9 +125,10 @@ public class UpdatePostCommandHandler(
         post.HeroImageUrl = string.IsNullOrWhiteSpace(postEditModel.HeroImageUrl) ? null : SecurityHelper.SterilizeLink(postEditModel.HeroImageUrl);
         post.IsOutdated = postEditModel.IsOutdated;
         post.RouteLink = UrlHelper.GenerateRouteLink(post.PubDateUtc.GetValueOrDefault(), postEditModel.Slug);
+        post.Keywords = ContentProcessor.GetKeywords(postEditModel.Keywords);
     }
 
-    private static void UpdateCats(PostEntity post, Guid[] catIds, CancellationToken ct)
+    private static void UpdateCats(PostEntity post, Guid[] catIds)
     {
         post.PostCategory.Clear();
         if (catIds.Length != 0)

--- a/src/Moonglade.Data.MySql/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.MySql/Configurations/PostConfiguration.cs
@@ -24,5 +24,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Title).HasMaxLength(128);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
         builder.Property(e => e.RouteLink).HasMaxLength(256);
+        builder.Property(e => e.Keywords).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data.PostgreSql/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.PostgreSql/Configurations/PostConfiguration.cs
@@ -24,5 +24,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Title).HasMaxLength(128);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
         builder.Property(e => e.RouteLink).HasMaxLength(256);
+        builder.Property(e => e.Keywords).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data.SqlServer/Configurations/PostConfiguration.cs
+++ b/src/Moonglade.Data.SqlServer/Configurations/PostConfiguration.cs
@@ -24,5 +24,6 @@ internal class PostConfiguration : IEntityTypeConfiguration<PostEntity>
         builder.Property(e => e.Title).HasMaxLength(128);
         builder.Property(e => e.HeroImageUrl).HasMaxLength(256);
         builder.Property(e => e.RouteLink).HasMaxLength(256);
+        builder.Property(e => e.Keywords).HasMaxLength(256);
     }
 }

--- a/src/Moonglade.Data/Entities/PostEntity.cs
+++ b/src/Moonglade.Data/Entities/PostEntity.cs
@@ -28,6 +28,7 @@ public class PostEntity
     public bool IsFeatured { get; set; }
     public string RouteLink { get; set; }
     public string PostStatus { get; set; }
+    public string Keywords { get; set; }
 
     public ICollection<CommentEntity> Comments { get; set; }
     public ICollection<PostCategoryEntity> PostCategory { get; set; }

--- a/src/Moonglade.Utils.Tests/ContentProcessorTests.cs
+++ b/src/Moonglade.Utils.Tests/ContentProcessorTests.cs
@@ -503,6 +503,162 @@ public class ContentProcessorTests
 
     #endregion
 
+    #region GetKeywords Tests
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData("  \t  \n  ", null)]
+    public void GetKeywords_WithNullOrWhitespace_ReturnsNull(string rawKeywords, string expected)
+    {
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithSingleKeyword_ReturnsTrimmedKeyword()
+    {
+        // Arrange
+        const string rawKeywords = "  technology  ";
+        const string expected = "technology";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithMultipleKeywords_ReturnsCommaSeparatedTrimmedKeywords()
+    {
+        // Arrange
+        const string rawKeywords = "technology, programming, csharp";
+        const string expected = "technology,programming,csharp";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithKeywordsContainingWhitespace_TrimsEachKeyword()
+    {
+        // Arrange
+        const string rawKeywords = "  technology  ,   programming   ,  csharp  ";
+        const string expected = "technology,programming,csharp";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithDuplicateKeywords_RemovesDuplicates()
+    {
+        // Arrange
+        const string rawKeywords = "technology,programming,technology,csharp,programming";
+        const string expected = "technology,programming,csharp";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithDuplicateKeywordsDifferentCasing_TreatsAsDistinct()
+    {
+        // Arrange
+        const string rawKeywords = "Technology,technology,TECHNOLOGY,Programming";
+        const string expected = "Technology,technology,TECHNOLOGY,Programming";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithEmptyKeywordsBetweenCommas_FiltersOutEmptyKeywords()
+    {
+        // Arrange
+        const string rawKeywords = "technology,,programming,   ,csharp,";
+        const string expected = "technology,programming,csharp";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithOnlyEmptyKeywords_ReturnsNull()
+    {
+        // Arrange
+        const string rawKeywords = " , ,   ,  , ";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithComplexMixedInput_HandlesCorrectly()
+    {
+        // Arrange
+        const string rawKeywords = "  ASP.NET Core  , ,   Entity Framework   , ASP.NET Core ,  Blazor  ,   ,  C# Programming  ,";
+        const string expected = "ASP.NET Core,Entity Framework,Blazor,C# Programming";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("keyword1", "keyword1")]
+    [InlineData("keyword1,keyword2", "keyword1,keyword2")]
+    [InlineData("a,b,c,d,e", "a,b,c,d,e")]
+    public void GetKeywords_WithValidKeywords_PreservesOrder(string rawKeywords, string expected)
+    {
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetKeywords_WithSpecialCharactersInKeywords_PreservesSpecialCharacters()
+    {
+        // Arrange
+        const string rawKeywords = "C#, .NET 8, ASP.NET Core, Entity Framework 7.0, Visual Studio 2022";
+        const string expected = "C#,.NET 8,ASP.NET Core,Entity Framework 7.0,Visual Studio 2022";
+
+        // Act
+        var result = ContentProcessor.GetKeywords(rawKeywords);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+
     #region Integration Tests
 
     //[Fact]

--- a/src/Moonglade.Utils/ContentProcessor.cs
+++ b/src/Moonglade.Utils/ContentProcessor.cs
@@ -139,6 +139,21 @@ public static class ContentProcessor
         Text = 2
     }
 
+    public static string GetKeywords(string rawKeywords)
+    {
+        if (string.IsNullOrWhiteSpace(rawKeywords)) return null;
+
+        var keywords = rawKeywords.Split(',')
+            .Select(k => k.Trim())
+            .Where(k => !string.IsNullOrWhiteSpace(k))
+            .Distinct()
+            .ToArray();
+
+        if (keywords.Length == 0) return null;
+
+        return string.Join(',', keywords);
+    }
+
     #region Private Methods
 
     private static string RemoveTagsBackup(string html)

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -127,7 +127,7 @@
             <div class="col-md-3 col-xl-2">
                 <div class="card mb-3">
                     <div class="card-body">
-                        <div class="form-check form-switch mb-2">
+                        <div class="form-check form-switch">
                             <input type="checkbox" name="EnableComment" value="true" class="form-check-input" @(Model.ViewModel.EnableComment ? "checked" : null)>
                             <label asp-for="ViewModel.EnableComment" class="form-check-label"></label>
                         </div>
@@ -135,7 +135,7 @@
                             <input type="checkbox" name="FeedIncluded" value="true" class="form-check-input" @(Model.ViewModel.FeedIncluded ? "checked" : null)>
                             <label asp-for="ViewModel.FeedIncluded" class="form-check-label"></label>
                         </div>
-                        <div class="form-check form-switch mb-2">
+                        <div class="form-check form-switch">
                             <input type="checkbox" name="Featured" value="true" class="form-check-input" @(Model.ViewModel.Featured ? "checked" : null)>
                             <label asp-for="ViewModel.Featured" class="form-check-label"></label>
                         </div>

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -157,16 +157,6 @@
                                 @SharedLocalizer["Upload Image"]
                             </a>
                         </div>
-
-                        @if (Model.ViewModel.PostId != Guid.Empty)
-                        {
-                            <div class="mt-2">
-                                <a class="btn btn-sm btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#changePublishDateModal">
-                                    <i class="bi-clock-history"></i>
-                                    @SharedLocalizer["Change Publish Date"]
-                                </a>
-                            </div>
-                        }
                     </div>
                     <div class="card-body border-top">
                         <h6 class="card-subtitle mb-3 text-muted">
@@ -204,6 +194,16 @@
                         }
                     </div>
                 </div>
+
+                @if (Model.ViewModel.PostId != Guid.Empty)
+                {
+                    <div class="text-center mb-2">
+                        <a class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#changePublishDateModal">
+                            <i class="bi-clock-history"></i>
+                            @SharedLocalizer["Change Publish Date"]
+                        </a>
+                    </div>
+                }
 
                 @if (Model.ViewModel.PostStatus == PostStatusConstants.Published)
                 {

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -159,6 +159,14 @@
                         </div>
                     </div>
                     <div class="card-body border-top">
+                        <div class="form-floating">
+                            <textarea asp-for="ViewModel.Keywords"
+                                      class="form-control form-control-sm"
+                                      placeholder="@Html.DisplayNameFor(m => m.ViewModel.Keywords)"></textarea>
+                            <label class="form-label" asp-for="ViewModel.Keywords"></label>
+                        </div>
+                    </div>
+                    <div class="card-body border-top">
                         <h6 class="card-subtitle mb-3 text-muted">
                             <i class="bi-folder2 me-1"></i>
                             @SharedLocalizer["Categories"]
@@ -204,13 +212,6 @@
                         </a>
                     </div>
                 }
-
-                @if (Model.ViewModel.PostStatus == PostStatusConstants.Published)
-                {
-                    <div class="text-center">
-                        <a class="unpublish-link btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#unpublishPostModal">@SharedLocalizer["Unpublish this post"]</a>
-                    </div>
-                }
             </div>
         </div>
 
@@ -227,6 +228,11 @@
                     @SharedLocalizer["Update"]
                 }
             </button>
+
+            @if (Model.ViewModel.PostStatus == PostStatusConstants.Published)
+            {
+                <a class="unpublish-link btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#unpublishPostModal">@SharedLocalizer["Unpublish this post"]</a>
+            }
 
             @if (Model.ViewModel.PostStatus != PostStatusConstants.Published)
             {

--- a/src/Moonglade.Web/Pages/Post.cshtml
+++ b/src/Moonglade.Web/Pages/Post.cshtml
@@ -15,7 +15,11 @@
     ViewBag.PostLangCode = Model.Post.ContentLanguageCode;
     ViewBag.MetaDescription = Model.Post.ContentAbstract;
 
-    @if (Model.Post.Tags.Any())
+    @if (!string.IsNullOrWhiteSpace(Model.Post.Keywords))
+    {
+        ViewBag.Keywords = Model.Post.Keywords;
+    }
+    else if (Model.Post.Tags.Any())
     {
         ViewBag.Keywords = string.Join(", ", Model.Post.Tags.Select(t => t.NormalizedName));
     }
@@ -155,62 +159,62 @@
 
 <div class="@(BlogConfig.CommentSettings.EnableCommentSectionOnMobile ? null : "d-none d-md-block")">
 
-@if (!Helper.GetAppDomainData<bool>("IsReadonlyMode") && BlogConfig.CommentSettings.EnableComments)
-{
-    var days = DateTime.UtcNow.Date.Subtract(Model.Post.PubDateUtc.GetValueOrDefault()).Days;
+    @if (!Helper.GetAppDomainData<bool>("IsReadonlyMode") && BlogConfig.CommentSettings.EnableComments)
+    {
+        var days = DateTime.UtcNow.Date.Subtract(Model.Post.PubDateUtc.GetValueOrDefault()).Days;
 
-    if (BlogConfig.CommentSettings.CloseCommentAfterDays > 0 && days > BlogConfig.CommentSettings.CloseCommentAfterDays)
-    {
-        <div class="text-muted text-center">
-            <span class="bi-dash-circle"></span>
-            @SharedLocalizer["Comment is closed."]
-        </div>
-    }
-    else
-    {
-        switch (BlogConfig.CommentSettings.CommentProvider)
+        if (BlogConfig.CommentSettings.CloseCommentAfterDays > 0 && days > BlogConfig.CommentSettings.CloseCommentAfterDays)
         {
-            case CommentProvider.BuiltIn:
-                <div class="d-print-none">
-                    @if (Model.Post.CommentEnabled)
-                    {
-                        <section class="comment-form-containter rounded-3 shadow-sm border bg-white mb-4">
-                            <h5 class="card-subtitle mb-3 text-muted">
-                                <i class="bi-chat-left-text"></i>
-                                @SharedLocalizer["Comments"]
-                            </h5>
-                            <partial name="_CommentForm" />
-                        </section>
+            <div class="text-muted text-center">
+                <span class="bi-dash-circle"></span>
+                @SharedLocalizer["Comment is closed."]
+            </div>
+        }
+        else
+        {
+            switch (BlogConfig.CommentSettings.CommentProvider)
+            {
+                case CommentProvider.BuiltIn:
+                    <div class="d-print-none">
+                        @if (Model.Post.CommentEnabled)
+                        {
+                            <section class="comment-form-containter rounded-3 shadow-sm border bg-white mb-4">
+                                <h5 class="card-subtitle mb-3 text-muted">
+                                    <i class="bi-chat-left-text"></i>
+                                    @SharedLocalizer["Comments"]
+                                </h5>
+                                <partial name="_CommentForm" />
+                            </section>
 
-                        <div id="thx-for-comment" class="alert alert-warning" style="display: none;">
-                            @SharedLocalizer["Thanks, your comment is pending approval now."] <br />
-                            @SharedLocalizer["It will show up once blog administrator approved your comment."]
-                        </div>
+                            <div id="thx-for-comment" class="alert alert-warning" style="display: none;">
+                                @SharedLocalizer["Thanks, your comment is pending approval now."] <br />
+                                @SharedLocalizer["It will show up once blog administrator approved your comment."]
+                            </div>
 
-                        <div id="thx-for-comment-non-review" class="alert alert-success" style="display: none;">
-                            @SharedLocalizer["Thanks for your comment."] <br />
-                            @SharedLocalizer["Refresh the page to see your comment."]
-                        </div>
+                            <div id="thx-for-comment-non-review" class="alert alert-success" style="display: none;">
+                                @SharedLocalizer["Thanks for your comment."] <br />
+                                @SharedLocalizer["Refresh the page to see your comment."]
+                            </div>
 
-                        <section id="comments-list">
-                            @await Component.InvokeAsync("CommentList", new { postId = Model.Post.Id })
-                        </section>
-                    }
-                    else
-                    {
-                        <div class="text-muted text-center">
-                            <span class="bi-ban"></span>
-                            @SharedLocalizer["Comment of this post is disabled."]
-                        </div>
-                    }
-                </div>
-                break;
-            case CommentProvider.ThirdParty:
-                @Html.Raw(BlogConfig.CommentSettings.ThirdPartyCommentHtmlPitch)
-                break;
+                            <section id="comments-list">
+                                @await Component.InvokeAsync("CommentList", new { postId = Model.Post.Id })
+                            </section>
+                        }
+                        else
+                        {
+                            <div class="text-muted text-center">
+                                <span class="bi-ban"></span>
+                                @SharedLocalizer["Comment of this post is disabled."]
+                            </div>
+                        }
+                    </div>
+                    break;
+                case CommentProvider.ThirdParty:
+                    @Html.Raw(BlogConfig.CommentSettings.ThirdPartyCommentHtmlPitch)
+                    break;
+            }
         }
     }
-}
 
 </div>
 


### PR DESCRIPTION
This pull request introduces support for post-level keywords, allowing authors to specify custom keywords for each post. This enhancement includes database schema changes, updates to data models, backend logic for keyword processing, and UI modifications to enable keyword entry and display. The implementation ensures that keywords are properly sanitized, deduplicated, and stored with a maximum length constraint. Additionally, comprehensive unit tests have been added to verify the keyword processing logic.

**Database and Data Model Changes**
* Added a new nullable `Keywords` column to the `dbo.Post` table in the SQL migration script, and updated entity configurations for SQL Server, MySQL, and PostgreSQL to include the `Keywords` field with a maximum length of 256. (`Deployment/mssql-migration.sql`, `src/Moonglade.Data.SqlServer/Configurations/PostConfiguration.cs`, `src/Moonglade.Data.MySql/Configurations/PostConfiguration.cs`, `src/Moonglade.Data.PostgreSql/Configurations/PostConfiguration.cs`, [[1]](diffhunk://#diff-293c3521f3d8810959e053641f88c0b6468b2f306d04fc7153d1a84a06301758R133-R144) [[2]](diffhunk://#diff-17c93f8a71b8847aed9c9aa69dfd126ef015cf4c2557c1befb38178f1f3d4b92R27) [[3]](diffhunk://#diff-06a181d334eb07d8fc55a8333662984a003ddf0ca98154f8119a30b8d9a865d2R27) [[4]](diffhunk://#diff-6bbbd1d467d9c724bd7efb2701bf5ce6375569d9aa307288582f06a5230f2a2fR27)
* Added the `Keywords` property to the `PostEntity` class and the `PostEditModel` with appropriate display and length attributes. (`src/Moonglade.Data/Entities/PostEntity.cs`, `src/Moonglade.Core/PostFeature/PostEditModel.cs`, [[1]](diffhunk://#diff-b85cab00cd174b328263cbe1138ec5d84351ddaf1b68431f7049f6a95a2fa6d3R31) [[2]](diffhunk://#diff-89e14073a207bcae1aee542897c5214c4fea9251903b4ddfc9a5e1e37da53123R55-R58)

**Backend Logic and Processing**
* Implemented the `ContentProcessor.GetKeywords` method to sanitize, deduplicate, and format keywords, and integrated this processing into post creation and update flows. (`src/Moonglade.Utils/ContentProcessor.cs`, `src/Moonglade.Core/PostFeature/CreatePostCommand.cs`, `src/Moonglade.Core/PostFeature/UpdatePostCommand.cs`, [[1]](diffhunk://#diff-696869dfa0f2295a2ea3de5e109bcfd594f6510288cfebc751efc330f4824ca9R142-R156) [[2]](diffhunk://#diff-cb52d3357c67e657131204a8dac468bd3d221f81a1ba692349cdb3ab48e121f7R63) [[3]](diffhunk://#diff-343ff1373423d249fa800cb1bd8c5172969d3c48d2c5bc00267f775efb73b247R128-R131)
* Updated relevant methods to remove unnecessary parameters and ensure proper handling of categories during post updates. (`src/Moonglade.Core/PostFeature/UpdatePostCommand.cs`, [[1]](diffhunk://#diff-343ff1373423d249fa800cb1bd8c5172969d3c48d2c5bc00267f775efb73b247L30-R30) [[2]](diffhunk://#diff-343ff1373423d249fa800cb1bd8c5172969d3c48d2c5bc00267f775efb73b247R128-R131)

**User Interface Enhancements**
* Added a new textarea input for keywords in the post edit admin page, allowing authors to enter keywords separated by commas. Adjusted layout for better organization of post settings and publish date controls. (`src/Moonglade.Web/Pages/Admin/EditPost.cshtml`, [src/Moonglade.Web/Pages/Admin/EditPost.cshtmlL160-R167](diffhunk://#diff-9767a96d7075129eaf0abe7deedca063dbc3ee753e04cf3468e9dede4095888eL160-R167))
* Updated logic to set the page's meta keywords to use the post's custom keywords if available, otherwise fallback to tag names. (`src/Moonglade.Web/Pages/Post.cshtml`, [src/Moonglade.Web/Pages/Post.cshtmlL18-R22](diffhunk://#diff-b5ebf0a094613db049efb7ca6107c2cafdfb68f3619ef8b221a249fbcd919a53L18-R22))

**Testing**
* Added comprehensive unit tests for the `GetKeywords` method to cover various edge cases, including whitespace handling, deduplication, order preservation, special character support, and empty input scenarios. (`src/Moonglade.Utils.Tests/ContentProcessorTests.cs`, [src/Moonglade.Utils.Tests/ContentProcessorTests.csR506-R661](diffhunk://#diff-c6f18f8b30ac920bd77b41229cab09c6af0bd2898b458bf793ccaa9eeb24d8e6R506-R661))