### PR TITLE
Fix NullReferenceException in ReplyCommentCommandHandler

### DIFF
--- a/src/Moonglade.Comments/ReplyCommentCommand.cs
+++ b/src/Moonglade.Comments/ReplyCommentCommand.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Moonglade.Data;
 using Moonglade.Data.Entities;
+using Moonglade.Data.Specifications;
 using Moonglade.Utils;
 
 namespace Moonglade.Comments;
@@ -15,7 +16,8 @@ public class ReplyCommentCommandHandler(
 {
     public async Task<CommentReply> HandleAsync(ReplyCommentCommand request, CancellationToken ct)
     {
-        var cmt = await commentRepo.GetByIdAsync(request.CommentId, ct) ?? throw new InvalidOperationException($"Comment {request.CommentId} is not found.");
+        var cmt = await commentRepo.FirstOrDefaultAsync(new CommentWithPostByIdSpec(request.CommentId), ct)
+            ?? throw new InvalidOperationException($"Comment {request.CommentId} is not found.");
 
         var id = Guid.NewGuid();
         var model = new CommentReplyEntity

--- a/src/Moonglade.Data/Specifications/CommentSpec.cs
+++ b/src/Moonglade.Data/Specifications/CommentSpec.cs
@@ -34,3 +34,12 @@ public sealed class CommentWithRepliesSpec : Specification<CommentEntity>
         Query.Include(p => p.Replies);
     }
 }
+
+public sealed class CommentWithPostByIdSpec : Specification<CommentEntity>
+{
+    public CommentWithPostByIdSpec(Guid commentId)
+    {
+        Query.Where(c => c.Id == commentId);
+        Query.Include(c => c.Post);
+    }
+}


### PR DESCRIPTION
Introduces CommentWithPostByIdSpec to fetch comments with their associated post. Updates ReplyCommentCommandHandler to use this specification for retrieving comments, ensuring related post data is included.