### PR TITLE
Fix Paging Exception

### DIFF
--- a/src/Moonglade.Web/Pages/CategoryList.cshtml
+++ b/src/Moonglade.Web/Pages/CategoryList.cshtml
@@ -33,7 +33,7 @@ else
     </div>
 }
 
-@functions{
+@functions {
     [BindProperty(SupportsGet = true)]
     public int P { get; set; } = 1;
     public BasePagedList<PostDigest> Posts { get; set; }
@@ -42,6 +42,7 @@ else
     public async Task<IActionResult> OnGetAsync(string slug)
     {
         if (string.IsNullOrWhiteSpace(slug)) return NotFound();
+        if (P == 0) return BadRequest();
 
         var pageSize = BlogConfig.ContentSettings.PostListPageSize;
         Cat = await QueryMediator.QueryAsync(new GetCategoryBySlugQuery(slug));

--- a/src/Moonglade.Web/Pages/Index.cshtml
+++ b/src/Moonglade.Web/Pages/Index.cshtml
@@ -41,11 +41,7 @@ else
 
     public async Task<IActionResult> OnGetAsync(int p = 1)
     {
-        // Validate page parameter
-        if (p < 1)
-        {
-            return RedirectToPage("Index", new { p = 1 });
-        }
+        if (P == 0) return BadRequest();
 
         P = p;
         var pageSize = BlogConfig.ContentSettings.PostListPageSize;

--- a/src/Moonglade.Web/Pages/TagList.cshtml
+++ b/src/Moonglade.Web/Pages/TagList.cshtml
@@ -31,6 +31,8 @@ else
 
     public async Task<IActionResult> OnGet(string normalizedName)
     {
+        if (P == 0) return BadRequest();
+
         var tagResponse = await QueryMediator.QueryAsync(new GetTagQuery(normalizedName));
         if (tagResponse is null) return NotFound();
 


### PR DESCRIPTION
This pull request introduces a consistent validation check for the page parameter across multiple page handlers in the application. Instead of redirecting or allowing potentially invalid page requests, the code now returns a `BadRequest` response when the page parameter (`P`) is zero, improving error handling and input validation.

Input validation improvements:

* Updated `OnGetAsync` in `src/Moonglade.Web/Pages/Index.cshtml` to return `BadRequest` if `P` is zero, replacing the previous redirect logic for invalid page numbers.
* Added a check in `OnGetAsync` in `src/Moonglade.Web/Pages/CategoryList.cshtml` to return `BadRequest` if `P` is zero.
* Added a check in `OnGet` in `src/Moonglade.Web/Pages/TagList.cshtml` to return `BadRequest` if `P` is zero.