### PR TITLE
Patch v15.14.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,8 @@
     <Authors>Edi Wang</Authors>
     <Company>edi.wang</Company>
     <Copyright>(C) 2026 edi.wang@outlook.com</Copyright>
-    <AssemblyVersion>15.14.2</AssemblyVersion>
-    <FileVersion>15.14.2</FileVersion>
-    <Version>15.14.2</Version>
+    <AssemblyVersion>15.14.3</AssemblyVersion>
+    <FileVersion>15.14.3</FileVersion>
+    <Version>15.14.3</Version>
   </PropertyGroup>
 </Project>

--- a/src/Moonglade.Web/wwwroot/js/3rd/monaco.inline-attachment.js
+++ b/src/Moonglade.Web/wwwroot/js/3rd/monaco.inline-attachment.js
@@ -1,6 +1,22 @@
 ﻿(function () {
     'use strict';
 
+    function insertText(editor, text) {
+        var selection = editor.getSelection();
+        var range = selection;
+
+        if (!range && typeof monaco !== 'undefined' && monaco.Range) {
+            var position = editor.getPosition();
+            range = new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column);
+        }
+
+        editor.executeEdits('inline-attachment', [{
+            range: range,
+            text: text,
+            forceMoveMarkers: true
+        }]);
+    }
+
     inlineAttachment.editors.monaco = {
         Editor: function (monacoEditor) {
 
@@ -11,8 +27,7 @@
                     return me.getValue();
                 },
                 insertValue: function (val) {
-                    //inlineAttachment.util.insertTextAtCursor(input, val);
-                    insertTextToMonacoEditor(me, "\n" + val);
+                    insertText(me, "\n" + val);
                 },
                 setValue: function (val) {
                     me.setValue(val);


### PR DESCRIPTION
Introduce insertText(editor, text) to perform text insertion via editor.executeEdits, with a fallback to create a monaco.Range from the current position when no selection is available. Replace the previous insertTextToMonacoEditor call with insertText (prefixing the inserted value with a newline). This improves compatibility and ensures markers are moved correctly when inserting inline attachments into the Monaco editor.