### PR TITLE
Add auto-save, localization and lastModified support

### DIFF
--- a/src/Moonglade.Web/Commands/PostManagementCommands.cs
+++ b/src/Moonglade.Web/Commands/PostManagementCommands.cs
@@ -14,11 +14,11 @@ public record PostOperationContext(
     string UserAgent,
     string RootUrl);
 
-public record PostOperationResult(bool Succeeded, Guid PostId, string ErrorMessage)
+public record PostOperationResult(bool Succeeded, Guid PostId, DateTime? LastModifiedUtc, string ErrorMessage)
 {
-    public static PostOperationResult Success(Guid postId) => new(true, postId, string.Empty);
+    public static PostOperationResult Success(Guid postId, DateTime? lastModifiedUtc) => new(true, postId, lastModifiedUtc, string.Empty);
 
-    public static PostOperationResult Conflict(string errorMessage) => new(false, Guid.Empty, errorMessage);
+    public static PostOperationResult Conflict(string errorMessage) => new(false, Guid.Empty, null, errorMessage);
 }
 
 public record SavePostCommand(PostEditModel Payload, PostOperationContext Context) : ICommand<PostOperationResult>;
@@ -67,7 +67,7 @@ public class SavePostCommandHandler(
                 ProcessPublishedPost(model.LastModifiedUtc, postEntity, request.Context);
             }
 
-            return PostOperationResult.Success(postEntity.Id);
+            return PostOperationResult.Success(postEntity.Id, postEntity.LastModifiedUtc);
         }
         catch (Exception ex)
         {

--- a/src/Moonglade.Web/Controllers/PostController.cs
+++ b/src/Moonglade.Web/Controllers/PostController.cs
@@ -43,7 +43,11 @@ public class PostController(
             return Conflict(result.ErrorMessage);
         }
 
-        return Ok(new { result.PostId });
+        return Ok(new
+        {
+            result.PostId,
+            LastModifiedUtc = result.LastModifiedUtc?.ToString("u")
+        });
     }
 
     [TypeFilter(typeof(ClearBlogCache), Arguments =

--- a/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/EditPost.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "/admin/post/edit/{id:guid?}"
 
 @{
-    ViewBag.Title = "Edit Post";
+    ViewBag.Title = SharedLocalizer["Edit Post"];
     ViewBag.XData = "postEditor";
     ViewBag.HideAdminSidebar = true;
     ViewBag.AdminBackUrl = "javascript:history.go(-1);";
@@ -12,15 +12,49 @@
     <script type="module" src="~/js/app/admin.editpost.mjs"></script>
 }
 
+@section navbarActions {
+    <li id="auto-save-nav-item" class="nav-item d-none align-items-center me-2">
+        <div class="form-check form-switch text-white mb-0">
+            <input class="form-check-input"
+                   type="checkbox"
+                   role="switch"
+                   id="auto-save-toggle"
+                   aria-describedby="auto-save-status">
+            <label class="form-check-label small" for="auto-save-toggle">
+                <i class="bi-cloud-arrow-up me-1"></i>
+                @SharedLocalizer["Auto save"]
+            </label>
+        </div>
+        <span id="auto-save-status" class="navbar-text small text-white-50 ms-2"></span>
+    </li>
+}
+
 @section head {
     <link href="~/lib/tagify/tagify.css" rel="stylesheet" />
 }
 
 @Html.AntiForgeryToken()
 
+<div id="localizedStrings" style="display:none"
+     data-please-enter-content="@SharedLocalizer["Please enter content."]"
+     data-post-saved="@SharedLocalizer["Post saved successfully."]"
+     data-auto-save-on="@SharedLocalizer["Auto save is on."]"
+     data-auto-save-off="@SharedLocalizer["Auto save is off."]"
+     data-auto-save-waiting="@SharedLocalizer["Auto save is waiting for required fields."]"
+     data-auto-saved-at="@SharedLocalizer["Auto saved at {0}"]"
+     data-unsaved-changes="@SharedLocalizer["You have unsaved changes, are you sure to leave this page?"]"
+     data-modify-slug="@SharedLocalizer["Modify Slug"]"
+     data-modify-slug-warning="@SharedLocalizer["This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?"]"
+     data-unpublish-title="@SharedLocalizer["Unpublish Post"]"
+     data-unpublish-warning="@SharedLocalizer["Unpublishing this post will remove it from the public site and turn it into a draft. This will have impact on SEO. Please confirm."]"
+     data-post-unpublished="@SharedLocalizer["Post unpublished"]"
+     data-confirm="@SharedLocalizer["Confirm"]"
+     data-modify="@SharedLocalizer["Modify"]"
+     data-scheduled-for="@SharedLocalizer["Scheduled for: {0}"]"></div>
+
 <div x-show="isLoading" class="text-muted mb-3" :class="{ 'd-flex align-items-center': isLoading }">
     <div class="spinner-border spinner-border-sm me-2" role="status"></div>
-    <span>Loading post data...</span>
+    <span>@SharedLocalizer["Loading post data..."]</span>
 </div>
 
 <div x-show="!isLoading" x-cloak class="post-editor-container d-flex flex-column px-3 pt-2">
@@ -43,7 +77,7 @@
                         <div id="markdown-content-editor" class="monaco-target overflow-y-hidden"></div>
                         <textarea class="post-content-textarea d-none" x-model="formData.editorContent"></textarea>
                         <div class="md-editor-image-upload-area text-center border-secondary-subtle p-3 mt-1">
-                            Drag &amp; Drop / Paste image here to upload.
+                            @SharedLocalizer["Drag & Drop / Paste image here to upload."]
                         </div>
                     </div>
                 </template>
@@ -71,7 +105,7 @@
                             <input type="text"
                                    x-model="formData.slug"
                                    class="form-control form-control-sm"
-                                   placeholder="Slug"
+                                   placeholder="@SharedLocalizer["Slug"]"
                                    spellcheck="false"
                                    required
                                    pattern="[a-z0-9\-]+"
@@ -79,7 +113,7 @@
                                    x-bind:readonly="warnSlugModification && !slugUnlocked" />
                             <a x-show="warnSlugModification && !slugUnlocked"
                                x-on:click="unlockSlug"
-                               class="btn btn-warning btn-sm">Modify</a>
+                               class="btn btn-warning btn-sm">@SharedLocalizer["Modify"]</a>
                         </div>
 
                         <div class="input-group input-group-sm mb-2">
@@ -122,21 +156,21 @@
                                    x-model="formData.enableComment"
                                    class="form-check-input"
                                    id="enableComment">
-                            <label for="enableComment" class="form-check-label">Enable Comment</label>
+                            <label for="enableComment" class="form-check-label">@SharedLocalizer["Enable Comment"]</label>
                         </div>
                         <div class="form-check form-switch">
                             <input type="checkbox"
                                    x-model="formData.featured"
                                    class="form-check-input"
                                    id="featured">
-                            <label for="featured" class="form-check-label">Featured</label>
+                            <label for="featured" class="form-check-label">@SharedLocalizer["Featured"]</label>
                         </div>
                         <div class="form-check form-switch">
                             <input type="checkbox"
                                    x-model="formData.isOutdated"
                                    class="form-check-input"
                                    id="isOutdated">
-                            <label for="isOutdated" class="form-check-label">Mark as outdated</label>
+                            <label for="isOutdated" class="form-check-label">@SharedLocalizer["Mark as outdated"]</label>
                         </div>
                         <div class="form-check form-switch">
                             <input type="checkbox"
@@ -154,9 +188,9 @@
                         <div class="form-floating">
                             <textarea x-model="formData.keywords"
                                       class="form-control form-control-sm"
-                                      placeholder="Keywords (split by comma ',')"
+                                      placeholder="@SharedLocalizer["Keywords (split by comma ',')"]"
                                       id="post-keywords"></textarea>
-                            <label class="form-label" for="post-keywords">Keywords (split by comma ',')</label>
+                            <label class="form-label" for="post-keywords">@SharedLocalizer["Keywords (split by comma ',')"]</label>
                         </div>
                     </div>
                     <div class="card-body border-top">
@@ -234,7 +268,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="publishModalLabel">@SharedLocalizer["Publish"]</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@SharedLocalizer["Close"]"></button>
                     </div>
                     <div class="modal-body">
                         <div class="form-check form-switch mb-3">
@@ -242,14 +276,14 @@
                                    x-model="formData.feedIncluded"
                                    class="form-check-input"
                                    id="publishFeedIncluded">
-                            <label for="publishFeedIncluded" class="form-check-label">Include in feed and sitemap</label>
+                            <label for="publishFeedIncluded" class="form-check-label">@SharedLocalizer["Include in feed and sitemap"]</label>
                         </div>
                         <div class="form-check form-switch mb-3">
                             <input type="checkbox"
                                    x-model="enableSchedule"
                                    class="form-check-input"
                                    id="enableScheduleToggle">
-                            <label for="enableScheduleToggle" class="form-check-label">Schedule Publish</label>
+                            <label for="enableScheduleToggle" class="form-check-label">@SharedLocalizer["Schedule Publish"]</label>
                         </div>
                         <div x-show="enableSchedule" x-cloak class="mb-2">
                             <label class="form-label">@SharedLocalizer["Set a time in your local time zone to schedule the post to be automatically published."]</label>

--- a/src/Moonglade.Web/Resources/Program.de-DE.resx
+++ b/src/Moonglade.Web/Resources/Program.de-DE.resx
@@ -1254,4 +1254,61 @@
   <data name="{0} results" xml:space="preserve">
     <value>{0} Ergebnisse</value>
   </data>
+  <data name="Auto save" xml:space="preserve">
+    <value>Automatisch speichern</value>
+  </data>
+  <data name="Auto save is on." xml:space="preserve">
+    <value>Automatisches Speichern ist aktiviert.</value>
+  </data>
+  <data name="Auto save is off." xml:space="preserve">
+    <value>Automatisches Speichern ist deaktiviert.</value>
+  </data>
+  <data name="Auto save is waiting for required fields." xml:space="preserve">
+    <value>Automatisches Speichern wartet auf Pflichtfelder.</value>
+  </data>
+  <data name="Auto saved at {0}" xml:space="preserve">
+    <value>Automatisch gespeichert um {0}</value>
+  </data>
+  <data name="Please enter content." xml:space="preserve">
+    <value>Bitte geben Sie Inhalt ein.</value>
+  </data>
+  <data name="Post saved successfully." xml:space="preserve">
+    <value>Beitrag wurde erfolgreich gespeichert.</value>
+  </data>
+  <data name="Loading post data..." xml:space="preserve">
+    <value>Beitragsdaten werden geladen...</value>
+  </data>
+  <data name="Drag &amp; Drop / Paste image here to upload." xml:space="preserve">
+    <value>Bild hierher ziehen und ablegen oder einfügen, um es hochzuladen.</value>
+  </data>
+  <data name="Slug" xml:space="preserve">
+    <value>Slug</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Ändern</value>
+  </data>
+  <data name="Mark as outdated" xml:space="preserve">
+    <value>Als veraltet markieren</value>
+  </data>
+  <data name="Keywords (split by comma ',')" xml:space="preserve">
+    <value>Schlüsselwörter (durch Komma "," trennen)</value>
+  </data>
+  <data name="Schedule Publish" xml:space="preserve">
+    <value>Veröffentlichung planen</value>
+  </data>
+  <data name="Modify Slug" xml:space="preserve">
+    <value>Slug ändern</value>
+  </data>
+  <data name="This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?" xml:space="preserve">
+    <value>Dieser Beitrag ist bereits seit einiger Zeit veröffentlicht. Das Ändern des Slugs kann SEO beeinträchtigen. Möchten Sie fortfahren?</value>
+  </data>
+  <data name="Scheduled for: {0}" xml:space="preserve">
+    <value>Geplant für: {0}</value>
+  </data>
+  <data name="Edit Post" xml:space="preserve">
+    <value>Beitrag bearbeiten</value>
+  </data>
+  <data name="Post unpublished" xml:space="preserve">
+    <value>Beitrag wurde zurückgezogen</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.ja-JP.resx
+++ b/src/Moonglade.Web/Resources/Program.ja-JP.resx
@@ -1254,4 +1254,61 @@
   <data name="{0} results" xml:space="preserve">
     <value>{0} 件の結果</value>
   </data>
+  <data name="Auto save" xml:space="preserve">
+    <value>自動保存</value>
+  </data>
+  <data name="Auto save is on." xml:space="preserve">
+    <value>自動保存はオンです。</value>
+  </data>
+  <data name="Auto save is off." xml:space="preserve">
+    <value>自動保存はオフです。</value>
+  </data>
+  <data name="Auto save is waiting for required fields." xml:space="preserve">
+    <value>自動保存は必須項目の入力を待っています。</value>
+  </data>
+  <data name="Auto saved at {0}" xml:space="preserve">
+    <value>{0} に自動保存しました</value>
+  </data>
+  <data name="Please enter content." xml:space="preserve">
+    <value>内容を入力してください。</value>
+  </data>
+  <data name="Post saved successfully." xml:space="preserve">
+    <value>投稿を保存しました。</value>
+  </data>
+  <data name="Loading post data..." xml:space="preserve">
+    <value>投稿データを読み込んでいます...</value>
+  </data>
+  <data name="Drag &amp; Drop / Paste image here to upload." xml:space="preserve">
+    <value>画像をここにドラッグ＆ドロップ、または貼り付けてアップロードします。</value>
+  </data>
+  <data name="Slug" xml:space="preserve">
+    <value>Slug</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>変更</value>
+  </data>
+  <data name="Mark as outdated" xml:space="preserve">
+    <value>古い投稿としてマーク</value>
+  </data>
+  <data name="Keywords (split by comma ',')" xml:space="preserve">
+    <value>キーワード（カンマ "," 区切り）</value>
+  </data>
+  <data name="Schedule Publish" xml:space="preserve">
+    <value>公開を予約</value>
+  </data>
+  <data name="Modify Slug" xml:space="preserve">
+    <value>Slug を変更</value>
+  </data>
+  <data name="This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?" xml:space="preserve">
+    <value>この投稿は公開されてから時間が経っています。Slug を変更すると SEO に影響します。続行しますか？</value>
+  </data>
+  <data name="Scheduled for: {0}" xml:space="preserve">
+    <value>公開予約: {0}</value>
+  </data>
+  <data name="Edit Post" xml:space="preserve">
+    <value>投稿を編集</value>
+  </data>
+  <data name="Post unpublished" xml:space="preserve">
+    <value>投稿の公開を取り消しました</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.zh-Hans.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hans.resx
@@ -1254,4 +1254,61 @@
   <data name="{0} results" xml:space="preserve">
     <value>{0} 个结果</value>
   </data>
+  <data name="Auto save" xml:space="preserve">
+    <value>自动保存</value>
+  </data>
+  <data name="Auto save is on." xml:space="preserve">
+    <value>自动保存已开启。</value>
+  </data>
+  <data name="Auto save is off." xml:space="preserve">
+    <value>自动保存已关闭。</value>
+  </data>
+  <data name="Auto save is waiting for required fields." xml:space="preserve">
+    <value>自动保存正在等待必填字段。</value>
+  </data>
+  <data name="Auto saved at {0}" xml:space="preserve">
+    <value>已于 {0} 自动保存</value>
+  </data>
+  <data name="Please enter content." xml:space="preserve">
+    <value>请输入内容。</value>
+  </data>
+  <data name="Post saved successfully." xml:space="preserve">
+    <value>文章保存成功。</value>
+  </data>
+  <data name="Loading post data..." xml:space="preserve">
+    <value>正在加载文章数据...</value>
+  </data>
+  <data name="Drag &amp; Drop / Paste image here to upload." xml:space="preserve">
+    <value>将图片拖放或粘贴到此处上传。</value>
+  </data>
+  <data name="Slug" xml:space="preserve">
+    <value>Slug</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>修改</value>
+  </data>
+  <data name="Mark as outdated" xml:space="preserve">
+    <value>标记为过时</value>
+  </data>
+  <data name="Keywords (split by comma ',')" xml:space="preserve">
+    <value>关键词（用逗号 "," 分隔）</value>
+  </data>
+  <data name="Schedule Publish" xml:space="preserve">
+    <value>定时发布</value>
+  </data>
+  <data name="Modify Slug" xml:space="preserve">
+    <value>修改 Slug</value>
+  </data>
+  <data name="This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?" xml:space="preserve">
+    <value>此文章已发布一段时间，修改 Slug 会影响 SEO，是否继续？</value>
+  </data>
+  <data name="Scheduled for: {0}" xml:space="preserve">
+    <value>定时发布：{0}</value>
+  </data>
+  <data name="Edit Post" xml:space="preserve">
+    <value>编辑文章</value>
+  </data>
+  <data name="Post unpublished" xml:space="preserve">
+    <value>文章已取消发布</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.zh-Hant.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hant.resx
@@ -1254,4 +1254,61 @@
   <data name="{0} results" xml:space="preserve">
     <value>{0} 個結果</value>
   </data>
+  <data name="Auto save" xml:space="preserve">
+    <value>自動儲存</value>
+  </data>
+  <data name="Auto save is on." xml:space="preserve">
+    <value>自動儲存已開啟。</value>
+  </data>
+  <data name="Auto save is off." xml:space="preserve">
+    <value>自動儲存已關閉。</value>
+  </data>
+  <data name="Auto save is waiting for required fields." xml:space="preserve">
+    <value>自動儲存正在等待必填欄位。</value>
+  </data>
+  <data name="Auto saved at {0}" xml:space="preserve">
+    <value>已於 {0} 自動儲存</value>
+  </data>
+  <data name="Please enter content." xml:space="preserve">
+    <value>請輸入內容。</value>
+  </data>
+  <data name="Post saved successfully." xml:space="preserve">
+    <value>文章儲存成功。</value>
+  </data>
+  <data name="Loading post data..." xml:space="preserve">
+    <value>正在載入文章資料...</value>
+  </data>
+  <data name="Drag &amp; Drop / Paste image here to upload." xml:space="preserve">
+    <value>將圖片拖放或貼到此處上傳。</value>
+  </data>
+  <data name="Slug" xml:space="preserve">
+    <value>Slug</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>修改</value>
+  </data>
+  <data name="Mark as outdated" xml:space="preserve">
+    <value>標記為過時</value>
+  </data>
+  <data name="Keywords (split by comma ',')" xml:space="preserve">
+    <value>關鍵字（以逗號 "," 分隔）</value>
+  </data>
+  <data name="Schedule Publish" xml:space="preserve">
+    <value>排程發布</value>
+  </data>
+  <data name="Modify Slug" xml:space="preserve">
+    <value>修改 Slug</value>
+  </data>
+  <data name="This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?" xml:space="preserve">
+    <value>此文章已發布一段時間，修改 Slug 會影響 SEO，是否繼續？</value>
+  </data>
+  <data name="Scheduled for: {0}" xml:space="preserve">
+    <value>排程發布：{0}</value>
+  </data>
+  <data name="Edit Post" xml:space="preserve">
+    <value>編輯文章</value>
+  </data>
+  <data name="Post unpublished" xml:space="preserve">
+    <value>文章已取消發布</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/wwwroot/css/admin.css
+++ b/src/Moonglade.Web/wwwroot/css/admin.css
@@ -189,6 +189,22 @@
     flex-shrink: 0;
 }
 
+#auto-save-toggle {
+    background-color: rgba(0, 0, 0, 0.45);
+    border-color: rgba(255, 255, 255, 0.65);
+}
+
+    #auto-save-toggle:checked {
+        background-color: var(--bs-white) !important;
+        border-color: var(--bs-white) !important;
+        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23212529'/%3e%3c/svg%3e");
+    }
+
+    #auto-save-toggle:focus {
+        border-color: var(--bs-white);
+        box-shadow: 0 0 0 .2rem rgba(255, 255, 255, 0.25);
+    }
+
 .post-edit-form .CodeMirror {
     height: 620px;
 }

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpost.form.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpost.form.mjs
@@ -1,3 +1,5 @@
+import { getLocalizedString } from './utils.module.mjs';
+
 export function createFormMixin() {
     return {
         isFormDirty: false,
@@ -22,7 +24,7 @@ export function createFormMixin() {
 
             window.addEventListener('beforeunload', (event) => {
                 if (this.isFormDirty) {
-                    const message = 'You have unsaved changes, are you sure to leave this page?';
+                    const message = getLocalizedString('unsavedChanges');
                     event.returnValue = message;
                     return message;
                 }

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpost.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpost.mjs
@@ -3,19 +3,26 @@ import { fetch2 } from './httpService.mjs?v=1500';
 import { success, error } from './toastService.mjs';
 import { keepAlive } from './admin.editor.module.mjs';
 import { showConfirmModal, hideConfirmModal, escapeHtml } from './adminModal.mjs';
+import { getLocalizedString } from './utils.module.mjs';
 import { createSlugMixin } from './admin.editpost.slug.mjs';
 import { createEditorMixin } from './admin.editpost.editor.mjs';
 import { createTagifyMixin } from './admin.editpost.tagify.mjs';
 import { createScheduleMixin } from './admin.editpost.schedule.mjs';
 import { createFormMixin } from './admin.editpost.form.mjs';
 
+const AUTO_SAVE_INTERVAL_MS = 60 * 1000;
+const AUTO_SAVE_STORAGE_KEY = 'moonglade.postEditor.autoSaveEnabled';
+
 Alpine.data('postEditor', () => ({
     postId: null,
     isLoading: true,
     isSaving: false,
+    isAutoSaving: false,
     submitAction: 'save',
     categories: [],
     languages: [],
+    autoSaveTimerId: null,
+    lastSavedSnapshot: '',
 
     formData: {
         postId: '',
@@ -68,11 +75,13 @@ Alpine.data('postEditor', () => ({
 
         this.$nextTick(async () => {
             await this.initEditor();
-            this.initTagify();
+            await this.initTagify();
             this.updateMinScheduleDate();
             this.initScheduleState();
             this.setupKeyboardShortcuts();
             this.setupDirtyFormWarning();
+            this.updateSavedSnapshot();
+            this.setupAutoSave();
             keepAlive();
         });
     },
@@ -151,15 +160,72 @@ Alpine.data('postEditor', () => ({
         }
     },
 
+    getString(key) {
+        return getLocalizedString(key);
+    },
+
+    createPostRequestData() {
+        return {
+            postId: this.formData.postId || window.emptyGuid,
+            title: this.formData.title,
+            slug: this.formData.slug,
+            author: this.formData.author,
+            editorContent: this.formData.editorContent,
+            postStatus: this.formData.postStatus,
+            enableComment: this.formData.enableComment,
+            feedIncluded: this.formData.feedIncluded,
+            featured: this.formData.featured,
+            isOutdated: this.formData.isOutdated,
+            containsAiAssistedContent: this.formData.containsAiAssistedContent,
+            languageCode: this.formData.languageCode,
+            abstract: this.formData.abstract,
+            keywords: this.formData.keywords,
+            tags: this.formData.tags,
+            selectedCatIds: this.formData.selectedCatIds,
+            publishDate: this.formData.publishDate,
+            scheduledPublishTime: this.formData.scheduledPublishTime || null,
+            clientTimeZoneId: this.formData.clientTimeZoneId,
+            lastModifiedUtc: this.formData.lastModifiedUtc,
+            contentType: this.formData.contentType
+        };
+    },
+
+    createPostSnapshot() {
+        const { lastModifiedUtc, ...snapshot } = this.createPostRequestData();
+        return JSON.stringify(snapshot);
+    },
+
+    updateSavedSnapshot() {
+        this.syncEditorContent();
+        this.syncTags();
+        this.lastSavedSnapshot = this.createPostSnapshot();
+    },
+
+    validatePostForm(reportInvalid) {
+        const form = document.getElementById('post-edit-form');
+
+        if (form) {
+            const isValid = reportInvalid ? form.reportValidity() : form.checkValidity();
+            if (!isValid) return false;
+        }
+
+        if (!this.formData.editorContent) {
+            if (reportInvalid) {
+                error(this.getString('pleaseEnterContent'));
+            }
+            return false;
+        }
+
+        return true;
+    },
+
     async handleSubmit() {
         this.syncEditorContent();
 
-        if (!this.formData.editorContent) {
-            error('Please enter content.');
+        if (!this.validatePostForm(true)) {
             return;
         }
 
-        // Sync tags from tagify
         this.syncTags();
 
         if (this.submitAction === 'publish') {
@@ -171,40 +237,12 @@ Alpine.data('postEditor', () => ({
             }
         }
 
-        this.isSaving = true;
-        this.isFormDirty = false;
-
         try {
-            const requestData = {
-                postId: this.formData.postId || window.emptyGuid,
-                title: this.formData.title,
-                slug: this.formData.slug,
-                author: this.formData.author,
-                editorContent: this.formData.editorContent,
-                postStatus: this.formData.postStatus,
-                enableComment: this.formData.enableComment,
-                feedIncluded: this.formData.feedIncluded,
-                featured: this.formData.featured,
-                isOutdated: this.formData.isOutdated,
-                containsAiAssistedContent: this.formData.containsAiAssistedContent,
-                languageCode: this.formData.languageCode,
-                abstract: this.formData.abstract,
-                keywords: this.formData.keywords,
-                tags: this.formData.tags,
-                selectedCatIds: this.formData.selectedCatIds,
-                publishDate: this.formData.publishDate,
-                scheduledPublishTime: this.formData.scheduledPublishTime || null,
-                clientTimeZoneId: this.formData.clientTimeZoneId,
-                lastModifiedUtc: this.formData.lastModifiedUtc,
-                contentType: this.formData.contentType
-            };
-
-            const resp = await fetch2('/api/post/createoredit', 'POST', requestData);
+            const resp = await this.savePost();
 
             if (resp && resp.postId) {
-                this.postId = resp.postId;
-                this.formData.postId = resp.postId;
-                success('Post saved successfully.');
+                success(this.getString('postSaved'));
+                this.syncAutoSaveAvailability();
 
                 if (this.submitAction === 'preview') {
                     window.open(`/admin/post/preview/${resp.postId}`);
@@ -218,17 +256,145 @@ Alpine.data('postEditor', () => ({
         }
     },
 
+    async savePost() {
+        this.isSaving = true;
+
+        const resp = await fetch2('/api/post/createoredit', 'POST', this.createPostRequestData());
+
+        if (resp && resp.postId) {
+            this.postId = resp.postId;
+            this.formData.postId = resp.postId;
+            this.formData.lastModifiedUtc = resp.lastModifiedUtc || this.formData.lastModifiedUtc;
+            this.isFormDirty = false;
+            this.lastSavedSnapshot = this.createPostSnapshot();
+        }
+
+        return resp;
+    },
+
+    setupAutoSave() {
+        const toggle = document.getElementById('auto-save-toggle');
+        if (!toggle) return;
+
+        toggle.addEventListener('change', () => {
+            this.setAutoSaveEnabled(toggle.checked);
+        });
+
+        this.syncAutoSaveAvailability();
+    },
+
+    isDraftPost() {
+        return this.formData.postStatus === 'Draft';
+    },
+
+    syncAutoSaveAvailability() {
+        const item = document.getElementById('auto-save-nav-item');
+        const toggle = document.getElementById('auto-save-toggle');
+        const isAvailable = this.isDraftPost();
+
+        if (item) {
+            item.classList.toggle('d-none', !isAvailable);
+            item.classList.toggle('d-flex', isAvailable);
+        }
+
+        if (!isAvailable) {
+            if (toggle) {
+                toggle.checked = false;
+            }
+            this.stopAutoSave();
+            this.updateAutoSaveStatus('');
+            return;
+        }
+
+        const autoSaveEnabled = window.localStorage.getItem(AUTO_SAVE_STORAGE_KEY) === 'true';
+        if (toggle) {
+            toggle.checked = autoSaveEnabled;
+        }
+        this.setAutoSaveEnabled(autoSaveEnabled, false);
+    },
+
+    stopAutoSave() {
+        window.clearInterval(this.autoSaveTimerId);
+        this.autoSaveTimerId = null;
+    },
+
+    setAutoSaveEnabled(enabled, persist = true) {
+        if (enabled && !this.isDraftPost()) {
+            const toggle = document.getElementById('auto-save-toggle');
+            if (toggle) {
+                toggle.checked = false;
+            }
+            this.stopAutoSave();
+            this.updateAutoSaveStatus('');
+            return;
+        }
+
+        if (persist) {
+            window.localStorage.setItem(AUTO_SAVE_STORAGE_KEY, enabled ? 'true' : 'false');
+        }
+
+        this.stopAutoSave();
+
+        this.updateAutoSaveStatus(enabled ? this.getString('autoSaveOn') : this.getString('autoSaveOff'));
+
+        if (!enabled) return;
+
+        this.autoSaveTimerId = window.setInterval(() => {
+            this.autoSave();
+        }, AUTO_SAVE_INTERVAL_MS);
+    },
+
+    async autoSave() {
+        if (!this.isDraftPost() || this.isLoading || this.isSaving || this.isAutoSaving) return;
+
+        this.syncEditorContent();
+        this.syncTags();
+
+        if (!this.validatePostForm(false)) {
+            this.updateAutoSaveStatus(this.getString('autoSaveWaiting'));
+            return;
+        }
+
+        const currentSnapshot = this.createPostSnapshot();
+        if (currentSnapshot === this.lastSavedSnapshot) return;
+
+        this.isAutoSaving = true;
+        const originalSubmitAction = this.submitAction;
+        this.submitAction = 'save';
+
+        try {
+            const resp = await this.savePost();
+            if (resp && resp.postId) {
+                const savedAt = new Date().toLocaleTimeString();
+                this.updateAutoSaveStatus(this.getString('autoSavedAt').replace('{0}', savedAt));
+            }
+        } catch (err) {
+            error(err);
+        } finally {
+            this.isAutoSaving = false;
+            this.isSaving = false;
+            this.submitAction = originalSubmitAction;
+        }
+    },
+
+    updateAutoSaveStatus(message) {
+        const status = document.getElementById('auto-save-status');
+        if (status) {
+            status.textContent = message || '';
+        }
+    },
+
     openUnpublishModal() {
         showConfirmModal({
-            title: 'Unpublish Post',
-            body: `<div class="alert alert-warning">Unpublishing this post will remove it from the public site and turn it into a draft. This will have impact on SEO. Please confirm.</div><p>${escapeHtml(this.formData.title)}</p>`,
-            confirmText: 'Confirm',
+            title: this.getString('unpublishTitle'),
+            body: `<div class="alert alert-warning">${escapeHtml(this.getString('unpublishWarning'))}</div><p>${escapeHtml(this.formData.title)}</p>`,
+            confirmText: this.getString('confirm'),
             confirmClass: 'btn-danger',
             onConfirm: async () => {
                 try {
                     if (!this.postId) return;
                     await fetch2(`/api/post/${this.postId}/unpublish`, 'PUT', {});
-                    success('Post unpublished');
+                    success(this.getString('postUnpublished'));
                     location.reload();
                 } catch (err) {
                     error(err);

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpost.schedule.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpost.schedule.mjs
@@ -1,3 +1,5 @@
+import { getLocalizedString } from './utils.module.mjs';
+
 export function createScheduleMixin() {
     return {
         enableSchedule: false,
@@ -65,7 +67,8 @@ export function createScheduleMixin() {
                     displayTime = localDate.toLocaleString();
                 }
 
-                this.scheduleInfoHtml = `<i class="bi-clock"></i> <span>Scheduled for: ${displayTime}</span>`;
+                const scheduleText = getLocalizedString('scheduledFor').replace('{0}', displayTime);
+                this.scheduleInfoHtml = `<i class="bi-clock"></i> <span>${scheduleText}</span>`;
             } else {
                 this.scheduleInfoHtml = '';
             }

--- a/src/Moonglade.Web/wwwroot/js/app/admin.editpost.slug.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.editpost.slug.mjs
@@ -1,5 +1,5 @@
 import { showConfirmModal, hideConfirmModal } from './adminModal.mjs';
-import { slugify } from './utils.module.mjs';
+import { getLocalizedString, slugify } from './utils.module.mjs';
 
 export function createSlugMixin() {
     return {
@@ -17,9 +17,9 @@ export function createSlugMixin() {
 
         unlockSlug() {
             showConfirmModal({
-                title: 'Modify Slug',
-                body: '<div class="alert alert-warning">This post was published for a period of time, changing slug will result in breaking SEO, would you like to continue?</div>',
-                confirmText: 'Modify',
+                title: getLocalizedString('modifySlug'),
+                body: `<div class="alert alert-warning">${getLocalizedString('modifySlugWarning')}</div>`,
+                confirmText: getLocalizedString('modify'),
                 confirmClass: 'btn-warning',
                 onConfirm: () => {
                     this.slugUnlocked = true;


### PR DESCRIPTION
Expose post LastModifiedUtc in PostOperationResult and controller responses; include LastModifiedUtc when saving posts. Add auto-save feature in the post editor: UI toggle, CSS styling, persistent setting, interval timer, snapshot/validation logic and background save flow. Introduce localized strings and wire getLocalizedString into editor, form, schedule and slug mixins; update EditPost view to use SharedLocalizer and embed localized strings. Update multiple .resx resource files (de, ja, zh-Hans, zh-Hant) with new keys. Minor refactors: extract request/snapshot helpers and savePost method, and replace hardcoded messages with localized messages.