### PR TITLE
Add configurable comment rate limiting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Important configuration areas:
 | `Authentication:Provider` | Selects local auth or Microsoft Entra ID. | Yes | Entra ID settings live under `Authentication:EntraID`. |
 | `Authentication:Totp:Issuer` | Display issuer for local-account authenticator app QR codes. | Optional | Defaults to `Moonglade`; the TOTP secret is stored in `LocalAccountSettings`. |
 | `CaptchaSettings:SharedKey` | Shared key for stateless captcha tokens. | Yes for captcha | Replace default/example values before deployment. |
+| `CommentRateLimit` | Built-in comment submission rate limiting by client IP and post ID. | Optional | Uses a fixed window policy; captcha endpoint rate limiting is separate and not currently configured. |
 | `Webmention` | Webmention options, including source rate limiting. | Optional | Preserve protocol endpoint behavior. |
 | `Email` | Notification API endpoint/key/header. | Optional | Store real keys outside source control. |
 | `IndexNow` | API key, ping targets, and cooldown interval. | Optional | API key also maps the IndexNow verification file endpoint. |
@@ -67,12 +68,13 @@ Important configuration areas:
 
 - The public comment entry point is `Moonglade.Web.Controllers.CommentController`; comment creation is handled by `Moonglade.Features.Comment.CreateCommentCommand`.
 - Whether comments are enabled, require review, close after a number of days, or use word filtering comes from `IBlogConfig.CommentSettings`.
+- Built-in comment creation is also protected by host-level `CommentRateLimit` settings that partition requests by client IP and post ID.
 - Content moderation is abstracted in `Moonglade.Moderation` and supports local keyword filtering. Do not put moderation behavior directly in controllers.
 - Comments, replies, and Webmentions can trigger activity logs and email notifications. Slow external calls should go through existing events, `CannonService`, or background mechanisms instead of blocking request handlers.
 
 ### Configuration
 
-- Application-level configuration lives in `src/Moonglade.Web/appsettings.json`, including database, authentication, captcha, image storage, email, IndexNow, security headers, cache durations, and background task switches.
+- Application-level configuration lives in `src/Moonglade.Web/appsettings.json`, including database, authentication, captcha, comment rate limiting, image storage, email, IndexNow, security headers, cache durations, and background task switches.
 - Runtime blog settings are managed by `Moonglade.Configuration.BlogConfig` and persisted in the `BlogConfiguration` table. When adding a blog setting, follow the `IBlogSettings<T>` pattern, provide a default value, and consider initialization and update commands.
 - `/admin/settings` is the main UI for blog settings. Do not hard-code administrator-configurable blog behavior in the Web layer.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ Please update the default key in `appsettings.json`:
 
 To generate a shared key, please see [this document](https://github.com/EdiWang/Edi.Captcha.AspNetCore?tab=readme-ov-file#shared-key-stateless-captcha-recommended-for-scalable-applications-without-dpapi)
 
+### Comment Rate Limiting
+
+Built-in comment submissions are rate limited by the combination of client IP address and post ID. Configure the `CommentRateLimit` section in `appsettings.json`:
+
+```json
+"CommentRateLimit": {
+  "Enabled": true,
+  "PermitLimit": 5,
+  "WindowMinutes": 10
+}
+```
+
+`PermitLimit` is the number of comment submissions allowed for the same IP and post during each fixed window. `WindowMinutes` controls the fixed window length. Set `Enabled` to `false` to disable this host-level safeguard.
+
 ### Image Storage
 
 Configure the `ImageStorage` section in `appsettings.json` to choose where blog images are stored.

--- a/docs/tasks/task-comment-rate-limit.md
+++ b/docs/tasks/task-comment-rate-limit.md
@@ -1,0 +1,60 @@
+# Comment Rate Limit
+
+## Original Goal
+
+Add configurable rate limiting to the public built-in comment creation API. The limit must be partitioned by client IP and post ID, and captcha refresh rate limiting is out of scope.
+
+## Background
+
+The built-in public comment endpoint is `POST /api/comment/{postId}` in `Moonglade.Web.Controllers.CommentController`. Current protection includes stateless captcha, optional comment review, word filtering, and comment close-after-days settings. ASP.NET Core's built-in rate limiting middleware fits the Web host layer and can apply a named policy to only the comment creation action.
+
+## Scope
+
+- Add appsettings-backed comment rate limit options.
+- Add a named ASP.NET Core rate limiting policy partitioned by client IP and post ID.
+- Apply the policy only to the built-in comment creation endpoint.
+- Update durable documentation for the new configuration section.
+- Add focused tests for partition behavior and disabled behavior.
+
+## Out of Scope
+
+- Rate limiting captcha image/token generation.
+- Replacing captcha or adding third-party bot protection.
+- Adding an admin UI for the host-level rate limit settings.
+
+## Task Breakdown
+
+| No. | Task | Dependencies | Verification | Status |
+| --- | --- | --- | --- | --- |
+| 1 | Add options and policy | Existing Web configuration and Controller route values | Unit tests | Complete |
+| 2 | Wire DI, middleware, and endpoint attribute | Task 1 | Web build | Complete |
+| 3 | Add appsettings and docs | Task 1 | Search/docs review | Complete |
+| 4 | Run focused verification | Tasks 1-3 | Web tests and build | Complete |
+
+## Execution Order
+
+Implement the reusable policy first, then register it in the Web host and attach it to `CommentController.Create`. After behavior is wired, update `appsettings.json`, README, and AGENTS, then run focused tests and a Web build.
+
+## Current Progress
+
+Implemented `CommentRateLimitOptions`, `CommentRateLimitPolicy`, DI/middleware wiring, the `CommentController.Create` rate-limit attribute, appsettings defaults, README/AGENTS documentation, and focused Web tests. Verification passed.
+
+## Verification Log
+
+| Date | Command or check | Result | Notes |
+| --- | --- | --- | --- |
+| 2026-07-24 | `dotnet test src/Tests/Moonglade.Web.Tests/Moonglade.Web.Tests.csproj` | Passed | 123 tests passed. Existing NU1903 warnings for `System.Security.Cryptography.Xml` 10.0.7 were reported during restore/build. |
+| 2026-07-24 | `dotnet build src/Moonglade.Web/Moonglade.Web.csproj` | Passed | Build succeeded with 0 warnings and 0 errors. |
+
+## Issues and Resolutions
+
+- The first Web test run failed because `RequestPipelineRedirectTests` builds a minimal test host that calls `UseMoongladeRequestPipeline` without the full Web service registration. Added `builder.Services.AddRateLimiter()` to that test host.
+
+## Follow-ups
+
+- Consider separate captcha endpoint rate limiting later.
+- Consider content-based spam scoring separately from transport-level rate limiting.
+
+## Notes
+
+The partition key should use `ClientIPHelper.GetClientIP(HttpContext)` to stay aligned with existing forwarded-header behavior.

--- a/src/Moonglade.Web/Configuration/CommentRateLimitOptions.cs
+++ b/src/Moonglade.Web/Configuration/CommentRateLimitOptions.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Moonglade.Web.Configuration;
+
+public class CommentRateLimitOptions
+{
+    public const string SectionName = "CommentRateLimit";
+
+    public bool Enabled { get; set; } = true;
+
+    [Range(1, int.MaxValue)]
+    public int PermitLimit { get; set; } = 5;
+
+    [Range(1, int.MaxValue)]
+    public int WindowMinutes { get; set; } = 10;
+}

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -1,11 +1,13 @@
 ﻿using LiteBus.Commands.Abstractions;
 using LiteBus.Events.Abstractions;
 using LiteBus.Queries.Abstractions;
+using Microsoft.AspNetCore.RateLimiting;
 using Moonglade.ActivityLog;
 using Moonglade.BackgroundServices;
 using Moonglade.Data.DTO;
 using Moonglade.Email.Client;
 using Moonglade.Moderation;
+using Moonglade.Web.Services;
 using System.ComponentModel.DataAnnotations;
 
 namespace Moonglade.Web.Controllers;
@@ -20,6 +22,7 @@ public class CommentController(
 {
     [HttpPost("{postId:guid}")]
     [AllowAnonymous]
+    [EnableRateLimiting(CommentRateLimitPolicy.PolicyName)]
     [ServiceFilter(typeof(ValidateCaptcha))]
     public async Task<IActionResult> Create([NotEmpty] Guid postId, CommentRequest request)
     {

--- a/src/Moonglade.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Moonglade.Web/Extensions/ServiceCollectionExtensions.cs
@@ -6,8 +6,10 @@ using LiteBus.Events;
 using LiteBus.Extensions.Microsoft.DependencyInjection;
 using LiteBus.Messaging;
 using LiteBus.Queries;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Moonglade.BackgroundServices;
 using Moonglade.Data.PostgreSql;
 using Moonglade.Data.SqlServer;
@@ -47,6 +49,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IPasswordGenerator, DefaultPasswordGenerator>();
         services.AddMoongladeHealthChecks();
         services.AddMoongladeProblemDetails();
+        services.AddMoongladeCommentRateLimiting(configuration);
         services.AddMoongladeCoreServices(configuration);
         services.AddMoongladeDatabase(configuration);
         services.AddMoongladeInitializers();
@@ -206,6 +209,23 @@ public static class ServiceCollectionExtensions
                 context.ProblemDetails.Instance = context.HttpContext.Request.Path;
                 context.ProblemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier;
             };
+        });
+
+        return services;
+    }
+
+    private static IServiceCollection AddMoongladeCommentRateLimiting(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<CommentRateLimitOptions>()
+            .Bind(configuration.GetSection(CommentRateLimitOptions.SectionName))
+            .Validate(options => !options.Enabled || options.PermitLimit > 0, "CommentRateLimit:PermitLimit must be greater than 0 when rate limiting is enabled.")
+            .Validate(options => !options.Enabled || options.WindowMinutes > 0, "CommentRateLimit:WindowMinutes must be greater than 0 when rate limiting is enabled.")
+            .ValidateOnStart();
+
+        services.AddSingleton<CommentRateLimitPolicy>();
+        services.AddRateLimiter(options =>
+        {
+            options.AddPolicy<string, CommentRateLimitPolicy>(CommentRateLimitPolicy.PolicyName);
         });
 
         return services;

--- a/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
+++ b/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
@@ -36,6 +36,7 @@ public static class WebApplicationExtensions
         app.UseStaticFiles();
         app.UseRouting();
         app.UseAuthentication().UseAuthorization();
+        app.UseRateLimiter();
 
         return app;
     }

--- a/src/Moonglade.Web/Services/CommentRateLimitPolicy.cs
+++ b/src/Moonglade.Web/Services/CommentRateLimitPolicy.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using System.Globalization;
+using System.Threading.RateLimiting;
+
+namespace Moonglade.Web.Services;
+
+public class CommentRateLimitPolicy(IOptionsMonitor<CommentRateLimitOptions> options) : IRateLimiterPolicy<string>
+{
+    public const string PolicyName = "CommentByIpAndPost";
+
+    public Func<OnRejectedContext, CancellationToken, ValueTask> OnRejected => RejectAsync;
+
+    public RateLimitPartition<string> GetPartition(HttpContext httpContext)
+    {
+        var settings = options.CurrentValue;
+        var partitionKey = GetPartitionKey(httpContext);
+
+        if (!settings.Enabled)
+        {
+            return RateLimitPartition.GetNoLimiter(partitionKey);
+        }
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey,
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = settings.PermitLimit,
+                Window = TimeSpan.FromMinutes(settings.WindowMinutes),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                AutoReplenishment = true
+            });
+    }
+
+    internal static string GetPartitionKey(HttpContext httpContext)
+    {
+        var clientIp = ClientIPHelper.GetClientIP(httpContext);
+        if (string.IsNullOrWhiteSpace(clientIp))
+        {
+            clientIp = "unknown-ip";
+        }
+
+        var postId = httpContext.Request.RouteValues.TryGetValue("postId", out var routeValue)
+            ? routeValue?.ToString()
+            : null;
+
+        if (!Guid.TryParse(postId, out var parsedPostId))
+        {
+            postId = "unknown-post";
+        }
+        else
+        {
+            postId = parsedPostId.ToString("D", CultureInfo.InvariantCulture);
+        }
+
+        return $"{clientIp.Trim().ToLowerInvariant()}|{postId}";
+    }
+
+    private static async ValueTask RejectAsync(OnRejectedContext context, CancellationToken cancellationToken)
+    {
+        var response = context.HttpContext.Response;
+        response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            response.Headers.RetryAfter = Math.Ceiling(retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+        }
+
+        var problemDetailsService = context.HttpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+        await problemDetailsService.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = context.HttpContext,
+            ProblemDetails =
+            {
+                Status = StatusCodes.Status429TooManyRequests,
+                Title = "Too many comment submissions",
+                Detail = "Please wait before submitting another comment.",
+                Type = "https://tools.ietf.org/html/rfc6585#section-4"
+            }
+        });
+    }
+}

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -20,6 +20,11 @@
     "SharedKey": "ShMV26g193e7Lg0nBxmgFRXBMmHDGWhknWul4yXnVbE=",
     "TokenExpirationMinutes": 20
   },
+  "CommentRateLimit": {
+    "Enabled": true,
+    "PermitLimit": 5,
+    "WindowMinutes": 10
+  },
   "Webmention": {
     "SourceRateLimit": {
       "Enabled": true,

--- a/src/Tests/Moonglade.Web.Tests/CommentControllerRateLimitTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/CommentControllerRateLimitTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.RateLimiting;
+using Moonglade.Web.Controllers;
+using Moonglade.Web.Services;
+using System.Reflection;
+
+namespace Moonglade.Web.Tests;
+
+public class CommentControllerRateLimitTests
+{
+    [Fact]
+    public void Create_UsesCommentRateLimitPolicy()
+    {
+        var method = typeof(CommentController).GetMethod(nameof(CommentController.Create));
+
+        var attribute = method!.GetCustomAttribute<EnableRateLimitingAttribute>();
+
+        Assert.NotNull(attribute);
+        Assert.Equal(CommentRateLimitPolicy.PolicyName, attribute.PolicyName);
+    }
+}

--- a/src/Tests/Moonglade.Web.Tests/CommentRateLimitPolicyTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/CommentRateLimitPolicyTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moonglade.Web.Configuration;
+using Moonglade.Web.Services;
+using Moq;
+using System.Net;
+
+namespace Moonglade.Web.Tests;
+
+public class CommentRateLimitPolicyTests
+{
+    [Fact]
+    public void GetPartition_CombinesClientIpAndPostId()
+    {
+        var postId = Guid.NewGuid();
+        var policy = CreatePolicy(new CommentRateLimitOptions());
+        var context = CreateHttpContext(IPAddress.Parse("192.0.2.10"), postId);
+
+        var partition = policy.GetPartition(context);
+
+        Assert.Equal($"192.0.2.10|{postId:D}", partition.PartitionKey);
+    }
+
+    [Fact]
+    public void GetPartition_TracksDifferentPostsSeparatelyForSameIp()
+    {
+        var policy = CreatePolicy(new CommentRateLimitOptions());
+        var firstContext = CreateHttpContext(IPAddress.Parse("192.0.2.10"), Guid.NewGuid());
+        var secondContext = CreateHttpContext(IPAddress.Parse("192.0.2.10"), Guid.NewGuid());
+
+        var firstPartition = policy.GetPartition(firstContext);
+        var secondPartition = policy.GetPartition(secondContext);
+
+        Assert.NotEqual(firstPartition.PartitionKey, secondPartition.PartitionKey);
+    }
+
+    [Fact]
+    public void GetPartition_WhenEnabled_AppliesConfiguredFixedWindowLimit()
+    {
+        var policy = CreatePolicy(new CommentRateLimitOptions
+        {
+            Enabled = true,
+            PermitLimit = 1,
+            WindowMinutes = 10
+        });
+        var context = CreateHttpContext(IPAddress.Parse("192.0.2.10"), Guid.NewGuid());
+        var partition = policy.GetPartition(context);
+        using var limiter = partition.Factory(partition.PartitionKey);
+
+        using var firstLease = limiter.AttemptAcquire();
+        using var secondLease = limiter.AttemptAcquire();
+
+        Assert.True(firstLease.IsAcquired);
+        Assert.False(secondLease.IsAcquired);
+    }
+
+    [Fact]
+    public void GetPartition_WhenDisabled_AllowsRequests()
+    {
+        var policy = CreatePolicy(new CommentRateLimitOptions
+        {
+            Enabled = false,
+            PermitLimit = 1,
+            WindowMinutes = 10
+        });
+        var context = CreateHttpContext(IPAddress.Parse("192.0.2.10"), Guid.NewGuid());
+        var partition = policy.GetPartition(context);
+        using var limiter = partition.Factory(partition.PartitionKey);
+
+        using var firstLease = limiter.AttemptAcquire();
+        using var secondLease = limiter.AttemptAcquire();
+
+        Assert.True(firstLease.IsAcquired);
+        Assert.True(secondLease.IsAcquired);
+    }
+
+    private static CommentRateLimitPolicy CreatePolicy(CommentRateLimitOptions options)
+    {
+        var optionsMonitor = new Mock<IOptionsMonitor<CommentRateLimitOptions>>();
+        optionsMonitor.SetupGet(x => x.CurrentValue).Returns(options);
+
+        return new CommentRateLimitPolicy(optionsMonitor.Object);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(IPAddress remoteIpAddress, Guid postId)
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = remoteIpAddress;
+        context.Request.RouteValues["postId"] = postId.ToString("D");
+
+        return context;
+    }
+}

--- a/src/Tests/Moonglade.Web.Tests/RequestPipelineRedirectTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/RequestPipelineRedirectTests.cs
@@ -62,6 +62,7 @@ public class RequestPipelineRedirectTests
         builder.Services.AddProblemDetails();
         builder.Services.AddAuthentication();
         builder.Services.AddAuthorization();
+        builder.Services.AddRateLimiter();
 
         var app = builder.Build();
         app.UseMoongladeRequestPipeline(CreateCultures());


### PR DESCRIPTION
Introduces host-level rate limiting for built-in comment submissions using a named ASP.NET Core policy partitioned by client IP and post ID. The policy is wired into DI and middleware, applied to `CommentController.Create`, and supports enable/disable plus fixed-window settings via `CommentRateLimit` in appsettings. Adds focused Web tests and updates README/AGENTS docs, with a test host update to register rate limiter services in request pipeline tests.