### PR TITLE
Add comment submission guard with honeypot and timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Important configuration areas:
 | `Authentication:Totp:Issuer` | Display issuer for local-account authenticator app QR codes. | Optional | Defaults to `Moonglade`; the TOTP secret is stored in `LocalAccountSettings`. |
 | `CaptchaSettings:SharedKey` | Shared key for stateless captcha tokens. | Yes for captcha | Replace default/example values before deployment. |
 | `CommentRateLimit` | Built-in comment submission rate limiting by client IP and post ID. | Optional | Uses a fixed window policy; captcha endpoint rate limiting is separate and not currently configured. |
+| `CommentSubmissionGuard` | Built-in comment honeypot and elapsed-time checks. | Optional | Rejects filled honeypot fields, too-fast submissions, and stale form timestamps. |
 | `Webmention` | Webmention options, including source rate limiting. | Optional | Preserve protocol endpoint behavior. |
 | `Email` | Notification API endpoint/key/header. | Optional | Store real keys outside source control. |
 | `IndexNow` | API key, ping targets, and cooldown interval. | Optional | API key also maps the IndexNow verification file endpoint. |
@@ -69,12 +70,13 @@ Important configuration areas:
 - The public comment entry point is `Moonglade.Web.Controllers.CommentController`; comment creation is handled by `Moonglade.Features.Comment.CreateCommentCommand`.
 - Whether comments are enabled, require review, close after a number of days, or use word filtering comes from `IBlogConfig.CommentSettings`.
 - Built-in comment creation is also protected by host-level `CommentRateLimit` settings that partition requests by client IP and post ID.
+- Built-in comment creation checks `CommentSubmissionGuard` honeypot and elapsed-time fields before dispatching the create command.
 - Content moderation is abstracted in `Moonglade.Moderation` and supports local keyword filtering. Do not put moderation behavior directly in controllers.
 - Comments, replies, and Webmentions can trigger activity logs and email notifications. Slow external calls should go through existing events, `CannonService`, or background mechanisms instead of blocking request handlers.
 
 ### Configuration
 
-- Application-level configuration lives in `src/Moonglade.Web/appsettings.json`, including database, authentication, captcha, comment rate limiting, image storage, email, IndexNow, security headers, cache durations, and background task switches.
+- Application-level configuration lives in `src/Moonglade.Web/appsettings.json`, including database, authentication, captcha, comment rate limiting, comment submission guard settings, image storage, email, IndexNow, security headers, cache durations, and background task switches.
 - Runtime blog settings are managed by `Moonglade.Configuration.BlogConfig` and persisted in the `BlogConfiguration` table. When adding a blog setting, follow the `IBlogSettings<T>` pattern, provide a default value, and consider initialization and update commands.
 - `/admin/settings` is the main UI for blog settings. Do not hard-code administrator-configurable blog behavior in the Web layer.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ Built-in comment submissions are rate limited by the combination of client IP ad
 
 `PermitLimit` is the number of comment submissions allowed for the same IP and post during each fixed window. `WindowMinutes` controls the fixed window length. Set `Enabled` to `false` to disable this host-level safeguard.
 
+### Comment Submission Guard
+
+Built-in comment submissions also use a hidden honeypot field and form elapsed-time checks. Configure the `CommentSubmissionGuard` section in `appsettings.json`:
+
+```json
+"CommentSubmissionGuard": {
+  "Enabled": true,
+  "HoneypotEnabled": true,
+  "MinimumElapsedSeconds": 3,
+  "MaxFormAgeMinutes": 240
+}
+```
+
+`MinimumElapsedSeconds` rejects submissions that arrive too quickly after the comment form is rendered. `MaxFormAgeMinutes` rejects stale form timestamps; set it to `0` to disable the max-age check. Set `Enabled` to `false` to disable this guard.
+
 ### Image Storage
 
 Configure the `ImageStorage` section in `appsettings.json` to choose where blog images are stored.

--- a/docs/tasks/task-comment-submission-guard.md
+++ b/docs/tasks/task-comment-submission-guard.md
@@ -51,6 +51,8 @@ Implemented `CommentSubmissionGuardOptions`, `CommentSubmissionGuard`, request f
 ## Issues and Resolutions
 
 - Running Web tests and Web build in parallel caused transient CS2012 file-lock errors for shared project `obj` DLLs. Reran `dotnet build src/Moonglade.Web/Moonglade.Web.csproj` serially and it passed.
+- PR #988 review noted that refreshing `formRenderedUtc` with `Date.now()` could reject valid submissions when client and server clocks differ. Fixed by returning a new server-issued `FormRenderedUtc` value from `CommentController.Create` and using that value in `post.mjs`.
+- PR #988 review noted that `CommentSubmissionGuardResult` used null defaults for non-nullable string properties. Fixed by enabling nullable context in `CommentSubmissionGuard.cs` and marking `ModelStateKey` and `ErrorMessage` as nullable.
 
 ## Follow-ups
 

--- a/docs/tasks/task-comment-submission-guard.md
+++ b/docs/tasks/task-comment-submission-guard.md
@@ -1,0 +1,61 @@
+# Comment Submission Guard
+
+## Original Goal
+
+Add a honeypot field and submission elapsed-time check to the built-in public comment form.
+
+## Background
+
+The built-in comment form is rendered by `src/Moonglade.Web/Pages/_CommentForm.cshtml` and submitted by `src/Moonglade.Web/wwwroot/js/app/post.mjs` as JSON to `POST /api/comment/{postId}`. Existing protection includes stateless captcha and the new IP-plus-post rate limit. This task adds another lightweight anti-automation layer before comment creation.
+
+## Scope
+
+- Add host-level configuration for comment submission guard behavior.
+- Add request fields for a honeypot and form-render timestamp.
+- Validate that the honeypot is empty and the form was not submitted too quickly or with a stale timestamp.
+- Update the public comment form and post JavaScript payload.
+- Add focused Web tests and update long-lived documentation.
+
+## Out of Scope
+
+- Captcha endpoint rate limiting.
+- Third-party bot detection services.
+- Admin UI for these host-level settings.
+
+## Task Breakdown
+
+| No. | Task | Dependencies | Verification | Status |
+| --- | --- | --- | --- | --- |
+| 1 | Add options and guard service | Existing comment request shape | Unit tests | Complete |
+| 2 | Add Razor and JS fields | Task 1 | Web build | Complete |
+| 3 | Apply guard in controller | Task 1 | Controller tests | Complete |
+| 4 | Update config and docs | Tasks 1-3 | Search/docs review | Complete |
+| 5 | Run focused verification | Tasks 1-4 | Web tests and build | Complete |
+
+## Execution Order
+
+Implement the reusable guard service first, then update the request payload and UI fields, then call the guard from `CommentController.Create`. After behavior is covered by tests, update `appsettings.json`, README, and AGENTS.
+
+## Current Progress
+
+Implemented `CommentSubmissionGuardOptions`, `CommentSubmissionGuard`, request fields, Razor/JS payload changes, controller validation, appsettings defaults, README/AGENTS documentation, and focused tests. Verification passed.
+
+## Verification Log
+
+| Date | Command or check | Result | Notes |
+| --- | --- | --- | --- |
+| 2026-07-24 | `dotnet test src/Tests/Moonglade.Web.Tests/Moonglade.Web.Tests.csproj` | Passed | 129 tests passed. Existing NU1903 warnings for `System.Security.Cryptography.Xml` 10.0.7 were reported during restore/build. |
+| 2026-07-24 | `dotnet build src/Moonglade.Web/Moonglade.Web.csproj` | Passed after rerun | Initial parallel run hit Windows file locks in `obj`; serial rerun succeeded with 0 warnings and 0 errors. |
+| 2026-07-24 | `dotnet test src/Tests/Moonglade.Features.Tests/Moonglade.Features.Tests.csproj` | Passed | 87 tests passed. |
+
+## Issues and Resolutions
+
+- Running Web tests and Web build in parallel caused transient CS2012 file-lock errors for shared project `obj` DLLs. Reran `dotnet build src/Moonglade.Web/Moonglade.Web.csproj` serially and it passed.
+
+## Follow-ups
+
+- Consider stronger signed form tokens if this lightweight timing signal proves too easy to bypass.
+
+## Notes
+
+The post model caches post data, not the rendered Razor page, so a server-rendered form timestamp is generated per page response.

--- a/src/Moonglade.Features/Comment/CommentRequest.cs
+++ b/src/Moonglade.Features/Comment/CommentRequest.cs
@@ -17,6 +17,11 @@ public class CommentRequest : ICaptchableWithToken
     [DataType(DataType.EmailAddress)]
     public string Email { get; set; }
 
+    [MaxLength(128)]
+    public string Source { get; set; }
+
+    public long? FormRenderedUtc { get; set; }
+
     [Required]
     [StringLength(4)]
     public string CaptchaCode { get; set; }

--- a/src/Moonglade.Web/Configuration/CommentSubmissionGuardOptions.cs
+++ b/src/Moonglade.Web/Configuration/CommentSubmissionGuardOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Moonglade.Web.Configuration;
+
+public class CommentSubmissionGuardOptions
+{
+    public const string SectionName = "CommentSubmissionGuard";
+
+    public bool Enabled { get; set; } = true;
+
+    public bool HoneypotEnabled { get; set; } = true;
+
+    [Range(0, int.MaxValue)]
+    public int MinimumElapsedSeconds { get; set; } = 3;
+
+    [Range(0, int.MaxValue)]
+    public int MaxFormAgeMinutes { get; set; } = 240;
+}

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -77,7 +77,8 @@ public class CommentController(
 
         return Ok(new
         {
-            blogConfig.CommentSettings.RequireCommentReview
+            blogConfig.CommentSettings.RequireCommentReview,
+            FormRenderedUtc = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         });
     }
 

--- a/src/Moonglade.Web/Controllers/CommentController.cs
+++ b/src/Moonglade.Web/Controllers/CommentController.cs
@@ -18,6 +18,7 @@ public class CommentController(
         IQueryMediator queryMediator,
         IModeratorService moderator,
         IBlogConfig blogConfig,
+        ICommentSubmissionGuard submissionGuard,
         CannonService cannonService) : BlogControllerBase(commandMediator)
 {
     [HttpPost("{postId:guid}")]
@@ -34,6 +35,13 @@ public class CommentController(
         // Early validation checks
         var validationResult = ValidateCommentRequest(request);
         if (validationResult != null) return validationResult;
+
+        var submissionGuardResult = submissionGuard.Validate(request);
+        if (!submissionGuardResult.Succeeded)
+        {
+            ModelState.AddModelError(submissionGuardResult.ModelStateKey, submissionGuardResult.ErrorMessage);
+            return ValidationProblem(ModelState);
+        }
 
         // Apply word filtering
         var filterResult = await ApplyWordFilteringAsync(request);

--- a/src/Moonglade.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Moonglade.Web/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using LiteBus.Messaging;
 using LiteBus.Queries;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Moonglade.BackgroundServices;
@@ -50,6 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddMoongladeHealthChecks();
         services.AddMoongladeProblemDetails();
         services.AddMoongladeCommentRateLimiting(configuration);
+        services.AddMoongladeCommentSubmissionGuard(configuration);
         services.AddMoongladeCoreServices(configuration);
         services.AddMoongladeDatabase(configuration);
         services.AddMoongladeInitializers();
@@ -227,6 +229,20 @@ public static class ServiceCollectionExtensions
         {
             options.AddPolicy<string, CommentRateLimitPolicy>(CommentRateLimitPolicy.PolicyName);
         });
+
+        return services;
+    }
+
+    private static IServiceCollection AddMoongladeCommentSubmissionGuard(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<CommentSubmissionGuardOptions>()
+            .Bind(configuration.GetSection(CommentSubmissionGuardOptions.SectionName))
+            .Validate(options => !options.Enabled || options.MinimumElapsedSeconds >= 0, "CommentSubmissionGuard:MinimumElapsedSeconds must be 0 or greater.")
+            .Validate(options => !options.Enabled || options.MaxFormAgeMinutes >= 0, "CommentSubmissionGuard:MaxFormAgeMinutes must be 0 or greater.")
+            .ValidateOnStart();
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<ICommentSubmissionGuard, CommentSubmissionGuard>();
 
         return services;
     }

--- a/src/Moonglade.Web/Pages/_CommentForm.cshtml
+++ b/src/Moonglade.Web/Pages/_CommentForm.cshtml
@@ -1,4 +1,13 @@
 ﻿<form id="comment-form">
+    <input type="hidden" id="input-comment-form-rendered-utc" name="formRenderedUtc" value="@(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())" />
+    <div class="visually-hidden" aria-hidden="true">
+        <label for="input-comment-source">Website</label>
+        <input type="text"
+               id="input-comment-source"
+               name="source"
+               tabindex="-1"
+               autocomplete="off" />
+    </div>
     <div>
         <div class="row g-2 mb-2">
             <div class="col-md-5">

--- a/src/Moonglade.Web/Services/CommentSubmissionGuard.cs
+++ b/src/Moonglade.Web/Services/CommentSubmissionGuard.cs
@@ -1,13 +1,15 @@
+#nullable enable
+
 using Microsoft.Extensions.Options;
 
 namespace Moonglade.Web.Services;
 
 public interface ICommentSubmissionGuard
 {
-    CommentSubmissionGuardResult Validate(CommentRequest request);
+    CommentSubmissionGuardResult Validate(CommentRequest? request);
 }
 
-public record CommentSubmissionGuardResult(bool Succeeded, string ModelStateKey = null, string ErrorMessage = null)
+public record CommentSubmissionGuardResult(bool Succeeded, string? ModelStateKey = null, string? ErrorMessage = null)
 {
     public static CommentSubmissionGuardResult Success { get; } = new(true);
 
@@ -21,7 +23,7 @@ public class CommentSubmissionGuard(
 {
     private const string InvalidSubmissionMessage = "Invalid comment submission.";
 
-    public CommentSubmissionGuardResult Validate(CommentRequest request)
+    public CommentSubmissionGuardResult Validate(CommentRequest? request)
     {
         var settings = options.CurrentValue;
         if (!settings.Enabled || request is null)

--- a/src/Moonglade.Web/Services/CommentSubmissionGuard.cs
+++ b/src/Moonglade.Web/Services/CommentSubmissionGuard.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Options;
+
+namespace Moonglade.Web.Services;
+
+public interface ICommentSubmissionGuard
+{
+    CommentSubmissionGuardResult Validate(CommentRequest request);
+}
+
+public record CommentSubmissionGuardResult(bool Succeeded, string ModelStateKey = null, string ErrorMessage = null)
+{
+    public static CommentSubmissionGuardResult Success { get; } = new(true);
+
+    public static CommentSubmissionGuardResult Failure(string modelStateKey, string errorMessage) =>
+        new(false, modelStateKey, errorMessage);
+}
+
+public class CommentSubmissionGuard(
+    IOptionsMonitor<CommentSubmissionGuardOptions> options,
+    TimeProvider timeProvider) : ICommentSubmissionGuard
+{
+    private const string InvalidSubmissionMessage = "Invalid comment submission.";
+
+    public CommentSubmissionGuardResult Validate(CommentRequest request)
+    {
+        var settings = options.CurrentValue;
+        if (!settings.Enabled || request is null)
+        {
+            return CommentSubmissionGuardResult.Success;
+        }
+
+        if (settings.HoneypotEnabled && !string.IsNullOrWhiteSpace(request.Source))
+        {
+            return CommentSubmissionGuardResult.Failure(nameof(CommentRequest.Source), InvalidSubmissionMessage);
+        }
+
+        if (settings.MinimumElapsedSeconds <= 0 && settings.MaxFormAgeMinutes <= 0)
+        {
+            return CommentSubmissionGuardResult.Success;
+        }
+
+        if (!request.FormRenderedUtc.HasValue)
+        {
+            return CommentSubmissionGuardResult.Failure(nameof(CommentRequest.FormRenderedUtc), InvalidSubmissionMessage);
+        }
+
+        DateTimeOffset formRenderedAt;
+        try
+        {
+            formRenderedAt = DateTimeOffset.FromUnixTimeMilliseconds(request.FormRenderedUtc.Value);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return CommentSubmissionGuardResult.Failure(nameof(CommentRequest.FormRenderedUtc), InvalidSubmissionMessage);
+        }
+
+        var elapsed = timeProvider.GetUtcNow() - formRenderedAt;
+        if (settings.MinimumElapsedSeconds > 0 && elapsed < TimeSpan.FromSeconds(settings.MinimumElapsedSeconds))
+        {
+            return CommentSubmissionGuardResult.Failure(nameof(CommentRequest.FormRenderedUtc), InvalidSubmissionMessage);
+        }
+
+        if (settings.MaxFormAgeMinutes > 0 && elapsed > TimeSpan.FromMinutes(settings.MaxFormAgeMinutes))
+        {
+            return CommentSubmissionGuardResult.Failure(nameof(CommentRequest.FormRenderedUtc), InvalidSubmissionMessage);
+        }
+
+        return CommentSubmissionGuardResult.Success;
+    }
+}

--- a/src/Moonglade.Web/appsettings.json
+++ b/src/Moonglade.Web/appsettings.json
@@ -25,6 +25,12 @@
     "PermitLimit": 5,
     "WindowMinutes": 10
   },
+  "CommentSubmissionGuard": {
+    "Enabled": true,
+    "HoneypotEnabled": true,
+    "MinimumElapsedSeconds": 3,
+    "MaxFormAgeMinutes": 240
+  },
   "Webmention": {
     "SourceRateLimit": {
       "Enabled": true,

--- a/src/Moonglade.Web/wwwroot/js/app/post.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/post.mjs
@@ -31,7 +31,7 @@ async function submitComment(pid) {
     try {
         const data = await fetch2(`/api/comment/${pid}`, 'POST', { username, content, email, captchaCode, captchaToken, source, formRenderedUtc });
         commentForm.reset();
-        resetCommentFormRenderedAt();
+        resetCommentFormRenderedAt(data.formRenderedUtc);
         resetCaptchaImage();
 
         if (data.requireCommentReview) {
@@ -49,10 +49,10 @@ async function submitComment(pid) {
     }
 }
 
-function resetCommentFormRenderedAt() {
+function resetCommentFormRenderedAt(formRenderedUtc) {
     const input = document.querySelector('#input-comment-form-rendered-utc');
-    if (input) {
-        input.value = Date.now().toString();
+    if (input && Number.isFinite(formRenderedUtc)) {
+        input.value = formRenderedUtc.toString();
     }
 }
 

--- a/src/Moonglade.Web/wwwroot/js/app/post.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/post.mjs
@@ -19,6 +19,8 @@ async function submitComment(pid) {
     const email = document.querySelector('#input-comment-email').value;
     const captchaCode = document.querySelector('#captcha-code').value;
     const captchaToken = document.querySelector('#captcha-token').value;
+    const source = document.querySelector('#input-comment-source')?.value ?? '';
+    const formRenderedUtc = Number(document.querySelector('#input-comment-form-rendered-utc')?.value ?? 0);
 
     thxForComment.style.display = 'none';
     thxForCommentNonReview.style.display = 'none';
@@ -27,8 +29,9 @@ async function submitComment(pid) {
     btnSubmitComment.setAttribute('disabled', 'disabled');
 
     try {
-        const data = await fetch2(`/api/comment/${pid}`, 'POST', { username, content, email, captchaCode, captchaToken });
+        const data = await fetch2(`/api/comment/${pid}`, 'POST', { username, content, email, captchaCode, captchaToken, source, formRenderedUtc });
         commentForm.reset();
+        resetCommentFormRenderedAt();
         resetCaptchaImage();
 
         if (data.requireCommentReview) {
@@ -43,6 +46,13 @@ async function submitComment(pid) {
         loadingIndicator.style.display = 'none';
         btnSubmitComment.classList.remove('disabled');
         btnSubmitComment.removeAttribute('disabled');
+    }
+}
+
+function resetCommentFormRenderedAt() {
+    const input = document.querySelector('#input-comment-form-rendered-utc');
+    if (input) {
+        input.value = Date.now().toString();
     }
 }
 

--- a/src/Tests/Moonglade.Web.Tests/CommentControllerTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/CommentControllerTests.cs
@@ -12,6 +12,7 @@ using Moonglade.Data.DTO;
 using Moonglade.Features.Comment;
 using Moonglade.Moderation;
 using Moonglade.Web.Controllers;
+using Moonglade.Web.Services;
 using Moq;
 using System.Net;
 using System.Security.Claims;
@@ -32,6 +33,14 @@ public class CommentControllerTests
     private readonly RecordingCommandMediator _commandMediator = new();
     private readonly Mock<IQueryMediator> _queryMediator = new();
     private readonly Mock<IModeratorService> _moderator = new();
+    private readonly Mock<ICommentSubmissionGuard> _submissionGuard = new();
+
+    public CommentControllerTests()
+    {
+        _submissionGuard
+            .Setup(x => x.Validate(It.IsAny<CommentRequest>()))
+            .Returns(CommentSubmissionGuardResult.Success);
+    }
 
     [Fact]
     public async Task Create_WhenCommentsDisabled_ReturnsForbid()
@@ -55,6 +64,22 @@ public class CommentControllerTests
         var problemResult = Assert.IsType<ObjectResult>(result);
         Assert.IsType<ValidationProblemDetails>(problemResult.Value);
         Assert.True(controller.ModelState.ContainsKey(nameof(CommentRequest.Email)));
+        Assert.Empty(_commandMediator.Commands);
+    }
+
+    [Fact]
+    public async Task Create_WhenSubmissionGuardRejectsRequest_ReturnsValidationProblem()
+    {
+        _submissionGuard
+            .Setup(x => x.Validate(It.IsAny<CommentRequest>()))
+            .Returns(CommentSubmissionGuardResult.Failure(nameof(CommentRequest.FormRenderedUtc), "Invalid comment submission."));
+        var controller = CreateController();
+
+        var result = await controller.Create(Guid.NewGuid(), CreateCommentRequest());
+
+        var problemResult = Assert.IsType<ObjectResult>(result);
+        Assert.IsType<ValidationProblemDetails>(problemResult.Value);
+        Assert.True(controller.ModelState.ContainsKey(nameof(CommentRequest.FormRenderedUtc)));
         Assert.Empty(_commandMediator.Commands);
     }
 
@@ -395,6 +420,7 @@ public class CommentControllerTests
             _queryMediator.Object,
             _moderator.Object,
             _blogConfig,
+            _submissionGuard.Object,
             CreateCannonService());
         var httpContext = new DefaultHttpContext();
 
@@ -434,6 +460,8 @@ public class CommentControllerTests
         Username = "reader",
         Content = "Hello world",
         Email = email,
+        Source = string.Empty,
+        FormRenderedUtc = DateTimeOffset.UtcNow.AddSeconds(-10).ToUnixTimeMilliseconds(),
         CaptchaCode = "1234",
         CaptchaToken = "token"
     };

--- a/src/Tests/Moonglade.Web.Tests/CommentControllerTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/CommentControllerTests.cs
@@ -129,6 +129,7 @@ public class CommentControllerTests
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.False((bool)okResult.Value!.GetType().GetProperty(nameof(CommentSettings.RequireCommentReview))!.GetValue(okResult.Value)!);
+        Assert.True((long)okResult.Value.GetType().GetProperty(nameof(CommentRequest.FormRenderedUtc))!.GetValue(okResult.Value)! > 0);
         var command = _commandMediator.Single<CreateCommentCommand>();
         Assert.Equal(postId, command.PostId);
         Assert.Same(request, command.Payload);

--- a/src/Tests/Moonglade.Web.Tests/CommentSubmissionGuardTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/CommentSubmissionGuardTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Options;
+using Moonglade.Features.Comment;
+using Moonglade.Web.Configuration;
+using Moonglade.Web.Services;
+using Moq;
+
+namespace Moonglade.Web.Tests;
+
+public class CommentSubmissionGuardTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 24, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Validate_WhenDisabled_AllowsRequest()
+    {
+        var guard = CreateGuard(new CommentSubmissionGuardOptions
+        {
+            Enabled = false,
+            HoneypotEnabled = true,
+            MinimumElapsedSeconds = 3,
+            MaxFormAgeMinutes = 240
+        });
+
+        var result = guard.Validate(new CommentRequest
+        {
+            Source = "filled",
+            FormRenderedUtc = Now.ToUnixTimeMilliseconds()
+        });
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_WhenHoneypotIsFilled_RejectsRequest()
+    {
+        var guard = CreateGuard(new CommentSubmissionGuardOptions());
+
+        var result = guard.Validate(CreateRequest(source: "https://spam.example", renderedAt: Now.AddSeconds(-10)));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(nameof(CommentRequest.Source), result.ModelStateKey);
+    }
+
+    [Fact]
+    public void Validate_WhenSubmittedTooQuickly_RejectsRequest()
+    {
+        var guard = CreateGuard(new CommentSubmissionGuardOptions
+        {
+            MinimumElapsedSeconds = 3,
+            MaxFormAgeMinutes = 240
+        });
+
+        var result = guard.Validate(CreateRequest(renderedAt: Now.AddSeconds(-1)));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(nameof(CommentRequest.FormRenderedUtc), result.ModelStateKey);
+    }
+
+    [Fact]
+    public void Validate_WhenFormTimestampIsExpired_RejectsRequest()
+    {
+        var guard = CreateGuard(new CommentSubmissionGuardOptions
+        {
+            MinimumElapsedSeconds = 3,
+            MaxFormAgeMinutes = 10
+        });
+
+        var result = guard.Validate(CreateRequest(renderedAt: Now.AddMinutes(-11)));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(nameof(CommentRequest.FormRenderedUtc), result.ModelStateKey);
+    }
+
+    [Fact]
+    public void Validate_WhenRequestLooksHuman_AllowsRequest()
+    {
+        var guard = CreateGuard(new CommentSubmissionGuardOptions
+        {
+            MinimumElapsedSeconds = 3,
+            MaxFormAgeMinutes = 240
+        });
+
+        var result = guard.Validate(CreateRequest(renderedAt: Now.AddSeconds(-10)));
+
+        Assert.True(result.Succeeded);
+    }
+
+    private static CommentSubmissionGuard CreateGuard(CommentSubmissionGuardOptions options)
+    {
+        var optionsMonitor = new Mock<IOptionsMonitor<CommentSubmissionGuardOptions>>();
+        optionsMonitor.SetupGet(x => x.CurrentValue).Returns(options);
+
+        return new CommentSubmissionGuard(optionsMonitor.Object, new FixedTimeProvider(Now));
+    }
+
+    private static CommentRequest CreateRequest(string source = "", DateTimeOffset? renderedAt = null) => new()
+    {
+        Source = source,
+        FormRenderedUtc = (renderedAt ?? Now.AddSeconds(-10)).ToUnixTimeMilliseconds()
+    };
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}


### PR DESCRIPTION
Adds a lightweight anti-automation layer for public comment submissions:

- New `CommentSubmissionGuardOptions` configuration section with honeypot, minimum elapsed seconds, and max form age settings
- `CommentSubmissionGuard` service validates honeypot emptiness and form render timestamp
- Hidden honeypot field and `formRenderedUtc` timestamp added to `_CommentForm.cshtml` and JS payload
- `CommentController` calls the guard before dispatching `CreateCommentCommand`
- Default config added to `appsettings.json`; README and AGENTS.md updated
- Focused unit tests for guard logic and controller integration