### PR TITLE
Add site verification file management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The solution file is `src/Moonglade.slnx`. The root `README.md` is the main depl
 | Area | Confirmed stack |
 | --- | --- |
 | Language/runtime | C# on .NET 10.0 / ASP.NET Core 10.0; projects target `net10.0` with implicit usings enabled. |
-| Web app model | ASP.NET Core Razor Pages for public/admin pages, controller-based APIs for admin JSON and public endpoints, endpoint routing for handlers such as health, robots, manifest, sitemap, FOAF, and OpenSearch. |
+| Web app model | ASP.NET Core Razor Pages for public/admin pages, controller-based APIs for admin JSON and public endpoints, endpoint routing for handlers such as health, robots, manifest, sitemap, FOAF, OpenSearch, and virtual site verification files. |
 | Architecture style | Multi-project modular solution with LiteBus command/query/event handlers and feature-oriented folders. |
 | Data access | EF Core with `BlogDbContext`; SQL Server via `Moonglade.Data.SqlServer`; PostgreSQL via `Moonglade.Data.PostgreSql`. |
 | Cache | `Edi.CacheAside.InMemory` with `BlogCachePartition` values `General`, `Post`, `Page`, `RssCategory`, and `AtomCategory`; widgets, sitemap, and uncategorized feeds use keys in the `General` partition. |
@@ -21,7 +21,7 @@ The solution file is `src/Moonglade.slnx`. The root `README.md` is the main depl
 | Authentication | Cookie-based local account authentication and Microsoft Entra ID through `Microsoft.Identity.Web`. |
 | Frontend | Server-rendered Razor, Bootstrap, Bootstrap Icons, Alpine.js, unified Moonglade.Editor for rich HTML post editing plus Markdown/CSS/HTML code-like modes, Tagify, Mermaid.js for Markdown diagrams on post reading pages, and project-local JavaScript modules under `src/Moonglade.Web/wwwroot/js/app`. |
 | Image storage | `IBlogImageStorage` abstraction with Azure Blob Storage, S3-compatible object storage through `AWSSDK.S3`, and local file system providers. |
-| External integrations | Webmention, IndexNow, email outbox delivery, local content moderation, Gravatar, Azure App Service logging, and Azure/Docker deployment assets. |
+| External integrations | Webmention, IndexNow, site ownership verification files, email outbox delivery, local content moderation, Gravatar, Azure App Service logging, and Azure/Docker deployment assets. |
 | Package management | NuGet package references in project files; no repository-level `Directory.Packages.props`, `NuGet.config`, or package lock file was found at the time this document was updated. |
 | Build tools | .NET SDK CLI, Visual Studio, VS Code task `dotnet build ${workspaceFolder}/src/Moonglade.Web/Moonglade.Web.csproj`, Docker multi-stage build, Docker Compose, and Azure Bicep/PowerShell deployment assets. |
 | Tests | xUnit v3, Moq, `Microsoft.NET.Test.Sdk`, `coverlet.collector`, EF Core InMemory/Sqlite patterns, and ASP.NET Core TestHost for Web tests. |
@@ -97,7 +97,8 @@ Important configuration areas:
 - Image storage is abstracted in `Moonglade.ImageStorage` and supports Azure Blob Storage, S3-compatible object storage, and the local file system. New image behavior should depend on `IBlogImageStorage`, not on a concrete provider.
 - Image uploads are validated by content before storage. SVG upload is supported, but SVG content must pass through the Web-layer sanitizer before primary or original image bytes are saved.
 - Themes and custom CSS are handled by `Moonglade.Theme` and `Moonglade.Web.Middleware.StyleSheetEndpoints`.
-- RSS, Atom, and OPML generation lives in `Moonglade.Syndication`; OpenSearch, FOAF, manifest, robots, and sitemap handlers live under `Moonglade.Web/Handlers`.
+- RSS, Atom, and OPML generation lives in `Moonglade.Syndication`; OpenSearch, FOAF, manifest, robots, sitemap, and site verification file handlers live under `Moonglade.Web/Handlers`.
+- Site verification files are managed from `/admin/settings/verification-files`, persisted in the database, and served as virtual root-level files. They are text-only (`.txt`, `.html`, `.htm`, `.xml`, `.json`), limited to 64 KB, and must use a single safe ASCII file name. Do not write these files into container `wwwroot`.
 - Preserve the public protocol endpoints listed in the README, including `/rss`, `/atom`, `/opml`, `/opensearch`, `/foaf.xml`, `/webmention`, `/health`, and `/health/ready`. Keep `/health` liveness-only; use `/health/ready` for database readiness.
 - Incoming Webmention source fetches must stay restricted to public HTTP/HTTPS URLs. Reject private, loopback, link-local, documentation, reserved, and other special-use source or redirect addresses before fetching content.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Key business areas include:
 
 - **Content publishing:** posts, drafts, scheduled posts, Markdown Mermaid diagrams, pages, featured/outdated flags, archives, recycle bin behavior, and route links for published posts.
 - **Reader interaction:** comments, replies, Webmentions, comment moderation, view counts, and optional email notifications.
-- **Site management:** runtime blog settings, widgets, themes, custom CSS, menus, image storage, account settings, and data import/export.
-- **Discovery and interoperability:** RSS, Atom, OPML, OpenSearch, FOAF, sitemap, robots.txt, IndexNow, reader-friendly markup, and health checks.
+- **Site management:** runtime blog settings, widgets, themes, custom CSS, menus, image storage, site verification files, account settings, and data import/export.
+- **Discovery and interoperability:** RSS, Atom, OPML, OpenSearch, FOAF, sitemap, robots.txt, IndexNow, root-level site ownership verification files, reader-friendly markup, and health checks.
 
 ## Repository Layout
 
@@ -101,6 +101,12 @@ dotnet test src/Tests/Moonglade.Web.Tests/Moonglade.Web.Tests.csproj
 ## ⚙️ Configuration
 
 > Most settings are managed in `appsettings.json`. For blog settings, use the `/admin/settings` UI.
+
+### Site Verification Files
+
+Some search engines and external services verify site ownership by requesting a specific file from the website root, such as `/google123.html` or `/ads.txt`. In Docker and Azure deployments, use `/admin/settings/verification-files` to add these files without modifying `wwwroot` inside the container.
+
+Verification files are stored in the Moonglade database and served from root-level virtual endpoints. Supported file types are `.txt`, `.html`, `.htm`, `.xml`, and `.json`; each file is limited to 64 KB and must use a single root-level file name with letters, digits, dots, underscores, or hyphens. Existing static files and built-in endpoints such as `/robots.txt`, `/sitemap.xml`, and `/manifest.webmanifest` keep priority.
 
 ### Authentication
 

--- a/docs/tasks/task-site-verification-files.md
+++ b/docs/tasks/task-site-verification-files.md
@@ -1,0 +1,81 @@
+# Site Verification Files
+
+## Original Goal
+
+Add a Docker-friendly way for blog administrators to make site ownership verification files available from the website root without editing files inside `wwwroot`.
+
+## Background
+
+Moonglade is an ASP.NET Core Razor Pages and controller-based application. Static files are served before endpoint routing, so real files under `wwwroot` should keep priority. The selected approach stores small text verification files in the database and maps strict root-level virtual file endpoints for public access.
+
+## Scope
+
+- Add persistence for root-level site verification files.
+- Add feature-layer commands and queries for managing verification files.
+- Add a public root-level GET/HEAD endpoint for enabled verification files.
+- Add authorized admin API, Razor UI, and JavaScript for list/create/update/delete/enable-disable.
+- Add cache invalidation, activity logging, tests, and documentation.
+
+## Out of Scope
+
+- Writing to the container image's `wwwroot` directory.
+- Supporting subdirectories or arbitrary binary files.
+- Adding external object storage for generic files.
+- Changing existing static file priority or public protocol endpoints.
+
+## Task Breakdown
+
+| No. | Task | Dependencies | Verification | Status |
+| --- | --- | --- | --- | --- |
+| 1 | Record task decisions | User confirmation | Task file exists | Done |
+| 2 | Add data entity/configuration and DbContext wiring | 1 | Build/tests compile model | Done |
+| 3 | Add feature commands, queries, validator, and DTOs | 2 | Feature tests | Done |
+| 4 | Add public root endpoint with cache validators | 3 | Web endpoint tests | Done |
+| 5 | Add admin API, UI, and JS | 3 | Web tests/build | Done |
+| 6 | Update localization and docs | 4, 5 | Build and resource checks | Done |
+| 7 | Run verification | 2-6 | dotnet build/test | Done |
+
+## Execution Order
+
+Implement the persistence and feature layer first, then map the public endpoint and admin API. Add UI and localization after API shape is stable. Finish with focused tests, documentation, and verification commands.
+
+## Current Progress
+
+Decisions confirmed by user:
+
+- Text files only: `.txt`, `.html`, `.htm`, `.xml`, `.json`.
+- Maximum file content size: 64 KB.
+- Root-level file names only, limited to ASCII letters, digits, dots, underscores, and hyphens.
+- Existing `wwwroot` static files keep priority.
+- Admin page path: `/admin/settings/verification-files`.
+- Support both file upload and manual file name/content entry.
+
+Implemented so far:
+
+- Added `SiteVerificationFileEntity`, EF configuration, provider-specific PostgreSQL timestamp override, `DbSet`, and clear-all-data cleanup.
+- Added feature-layer validation constants, DTOs, list/get/public queries, and create/update/delete/toggle commands.
+- Added public root-level GET/HEAD handler with cache headers, ETag, Last-Modified, and 304 support.
+- Added authorized admin API, `/admin/settings/verification-files` UI, Alpine module, localized resource entries, activity log events, and SQL Server/PostgreSQL migration script blocks.
+- Added Feature and Web tests for verification file management and public handler behavior.
+
+## Verification Log
+
+| Date | Command or check | Result | Notes |
+| --- | --- | --- | --- |
+| 2026-08-09 | Initial repository inspection | Passed | Read `AGENTS.md`, endpoint pipeline, existing asset/image patterns, and test structure. |
+| 2026-08-09 | `dotnet build src/Moonglade.Web/Moonglade.Web.csproj` | Passed | Final build passed with 0 warnings and 0 errors. |
+| 2026-08-09 | `dotnet test src/Tests/Moonglade.Features.Tests/Moonglade.Features.Tests.csproj --no-restore` | Passed | 95 tests passed after switching delete test to SQLite for `ExecuteDeleteAsync`. |
+| 2026-08-09 | `dotnet test src/Tests/Moonglade.Web.Tests/Moonglade.Web.Tests.csproj --no-restore` | Passed | 163 tests passed. |
+| 2026-08-09 | `dotnet test src/Tests/Moonglade.Setup.Tests/Moonglade.Setup.Tests.csproj --no-restore` | Passed | 18 tests passed after adding provider migration script blocks. |
+
+## Issues and Resolutions
+
+- EF Core InMemory does not support `ExecuteDeleteAsync`; the delete handler test uses SQLite in-memory, matching existing repository patterns for set-based delete tests.
+
+## Follow-ups
+
+None yet.
+
+## Notes
+
+The endpoint must avoid a broad root catch-all. It should only match one segment with an allowed extension and should preserve existing routes such as `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest`, `/opensearch`, `/admin`, `/api`, `/auth`, `/image`, and existing static files.

--- a/src/Moonglade.ActivityLog/EventType.cs
+++ b/src/Moonglade.ActivityLog/EventType.cs
@@ -66,6 +66,10 @@ public enum EventType
     // Asset operations (820-829)
     AvatarUpdated = 820,
     SiteIconUpdated = 821,
+    SiteVerificationFileCreated = 822,
+    SiteVerificationFileUpdated = 823,
+    SiteVerificationFileDeleted = 824,
+    SiteVerificationFileToggled = 825,
 
     // Widget operations (850-899)
     WidgetCreated = 850,

--- a/src/Moonglade.Data.PostgreSql/Configurations/SiteVerificationFileConfiguration.cs
+++ b/src/Moonglade.Data.PostgreSql/Configurations/SiteVerificationFileConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Moonglade.Data.Entities;
+
+namespace Moonglade.Data.PostgreSql.Configurations;
+
+internal class SiteVerificationFileConfiguration : Data.Configurations.SiteVerificationFileConfiguration
+{
+    protected override void ConfigureDateTimeColumns(EntityTypeBuilder<SiteVerificationFileEntity> builder)
+    {
+        builder.Property(e => e.CreatedTimeUtc).HasColumnType("timestamp");
+        builder.Property(e => e.LastModifiedTimeUtc).HasColumnType("timestamp");
+    }
+}

--- a/src/Moonglade.Data.PostgreSql/PostgreSqlBlogDbContext.cs
+++ b/src/Moonglade.Data.PostgreSql/PostgreSqlBlogDbContext.cs
@@ -30,5 +30,7 @@ public class PostgreSqlBlogDbContext : BlogDbContext
         modelBuilder.ApplyConfiguration(new ActivityLogConfiguration());
 
         base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfiguration(new SiteVerificationFileConfiguration());
     }
 }

--- a/src/Moonglade.Data.SqlServer/SqlServerBlogDbContext.cs
+++ b/src/Moonglade.Data.SqlServer/SqlServerBlogDbContext.cs
@@ -29,6 +29,7 @@ public class SqlServerBlogDbContext : BlogDbContext
         modelBuilder.ApplyConfiguration(new Data.Configurations.PageConfiguration());
         modelBuilder.ApplyConfiguration(new Data.Configurations.WidgetConfiguration());
         modelBuilder.ApplyConfiguration(new Data.Configurations.ActivityLogConfiguration());
+        modelBuilder.ApplyConfiguration(new Data.Configurations.SiteVerificationFileConfiguration());
 
         base.OnModelCreating(modelBuilder);
     }

--- a/src/Moonglade.Data/BlogDbContext.cs
+++ b/src/Moonglade.Data/BlogDbContext.cs
@@ -32,6 +32,7 @@ public class BlogDbContext : DbContext
     public virtual DbSet<WidgetEntity> Widget { get; set; }
     public virtual DbSet<ActivityLogEntity> ActivityLog { get; set; }
     public virtual DbSet<EmailOutboxMessageEntity> EmailOutboxMessage { get; set; }
+    public virtual DbSet<SiteVerificationFileEntity> SiteVerificationFile { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -39,6 +40,7 @@ public class BlogDbContext : DbContext
         modelBuilder.ApplyConfiguration(new CategoryConfiguration());
         modelBuilder.ApplyConfiguration(new ActivityLogConfiguration());
         modelBuilder.ApplyConfiguration(new EmailOutboxMessageConfiguration());
+        modelBuilder.ApplyConfiguration(new SiteVerificationFileConfiguration());
         modelBuilder.ApplyConfiguration(new PostViewDailyConfiguration());
         modelBuilder.ApplyConfiguration(new PostCategoryConfiguration());
         modelBuilder
@@ -84,6 +86,7 @@ public static class BlogDbContextExtension
             await context.Widget.ExecuteDeleteAsync();
             await context.ActivityLog.ExecuteDeleteAsync();
             await context.EmailOutboxMessage.ExecuteDeleteAsync();
+            await context.SiteVerificationFile.ExecuteDeleteAsync();
 
             await transaction.CommitAsync();
         });

--- a/src/Moonglade.Data/Configurations/SiteVerificationFileConfiguration.cs
+++ b/src/Moonglade.Data/Configurations/SiteVerificationFileConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Moonglade.Data.Entities;
+
+namespace Moonglade.Data.Configurations;
+
+public class SiteVerificationFileConfiguration : IEntityTypeConfiguration<SiteVerificationFileEntity>
+{
+    public void Configure(EntityTypeBuilder<SiteVerificationFileEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedNever();
+        builder.Property(e => e.FileName).IsRequired().HasMaxLength(128);
+        builder.Property(e => e.NormalizedFileName).IsRequired().HasMaxLength(128);
+        builder.Property(e => e.Content).IsRequired().HasMaxLength(65536);
+        builder.Property(e => e.ContentType).IsRequired().HasMaxLength(64);
+        builder.HasIndex(e => e.NormalizedFileName).IsUnique();
+        ConfigureDateTimeColumns(builder);
+    }
+
+    protected virtual void ConfigureDateTimeColumns(EntityTypeBuilder<SiteVerificationFileEntity> builder)
+    {
+        builder.Property(e => e.CreatedTimeUtc).HasColumnType("datetime");
+        builder.Property(e => e.LastModifiedTimeUtc).HasColumnType("datetime");
+    }
+}

--- a/src/Moonglade.Data/Entities/SiteVerificationFileEntity.cs
+++ b/src/Moonglade.Data/Entities/SiteVerificationFileEntity.cs
@@ -1,0 +1,20 @@
+namespace Moonglade.Data.Entities;
+
+public class SiteVerificationFileEntity
+{
+    public Guid Id { get; set; }
+
+    public string FileName { get; set; }
+
+    public string NormalizedFileName { get; set; }
+
+    public string Content { get; set; }
+
+    public string ContentType { get; set; }
+
+    public bool IsEnabled { get; set; }
+
+    public DateTime CreatedTimeUtc { get; set; }
+
+    public DateTime LastModifiedTimeUtc { get; set; }
+}

--- a/src/Moonglade.Features/SiteVerification/CreateSiteVerificationFileCommand.cs
+++ b/src/Moonglade.Features/SiteVerification/CreateSiteVerificationFileCommand.cs
@@ -1,0 +1,47 @@
+using LiteBus.Commands.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record CreateSiteVerificationFileCommand(string FileName, string Content, bool IsEnabled)
+    : ICommand<SiteVerificationFileCommandResult>;
+
+public class CreateSiteVerificationFileCommandHandler(
+    BlogDbContext db,
+    ILogger<CreateSiteVerificationFileCommandHandler> logger)
+    : ICommandHandler<CreateSiteVerificationFileCommand, SiteVerificationFileCommandResult>
+{
+    public async Task<SiteVerificationFileCommandResult> HandleAsync(CreateSiteVerificationFileCommand request, CancellationToken ct)
+    {
+        var validation = SiteVerificationFileConstants.Validate(request.FileName, request.Content);
+        if (!validation.Succeeded)
+        {
+            return SiteVerificationFileCommandResult.ValidationFailed(validation.ErrorMessage);
+        }
+
+        var normalizedFileName = SiteVerificationFileConstants.NormalizeFileName(request.FileName);
+        if (await db.SiteVerificationFile.AnyAsync(f => f.NormalizedFileName == normalizedFileName, ct))
+        {
+            return SiteVerificationFileCommandResult.DuplicateFileName();
+        }
+
+        var now = DateTime.UtcNow;
+        var entity = new SiteVerificationFileEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = request.FileName,
+            NormalizedFileName = normalizedFileName,
+            Content = request.Content,
+            ContentType = SiteVerificationFileConstants.GetContentType(request.FileName),
+            IsEnabled = request.IsEnabled,
+            CreatedTimeUtc = now,
+            LastModifiedTimeUtc = now
+        };
+
+        await db.SiteVerificationFile.AddAsync(entity, ct);
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation("Created site verification file: {FileName}", entity.FileName);
+        return SiteVerificationFileCommandResult.Done(entity);
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/DeleteSiteVerificationFileCommand.cs
+++ b/src/Moonglade.Features/SiteVerification/DeleteSiteVerificationFileCommand.cs
@@ -1,0 +1,25 @@
+using LiteBus.Commands.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record DeleteSiteVerificationFileCommand(Guid Id) : ICommand<OperationCode>;
+
+public class DeleteSiteVerificationFileCommandHandler(
+    BlogDbContext db,
+    ILogger<DeleteSiteVerificationFileCommandHandler> logger)
+    : ICommandHandler<DeleteSiteVerificationFileCommand, OperationCode>
+{
+    public async Task<OperationCode> HandleAsync(DeleteSiteVerificationFileCommand request, CancellationToken ct)
+    {
+        if (!await db.SiteVerificationFile.AnyAsync(f => f.Id == request.Id, ct))
+        {
+            return OperationCode.ObjectNotFound;
+        }
+
+        await db.SiteVerificationFile.Where(f => f.Id == request.Id).ExecuteDeleteAsync(ct);
+
+        logger.LogInformation("Deleted site verification file: {FileId}", request.Id);
+        return OperationCode.Done;
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/GetPublicSiteVerificationFileQuery.cs
+++ b/src/Moonglade.Features/SiteVerification/GetPublicSiteVerificationFileQuery.cs
@@ -1,0 +1,22 @@
+using LiteBus.Queries.Abstractions;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record GetPublicSiteVerificationFileQuery(string FileName) : IQuery<PublicSiteVerificationFile>;
+
+public class GetPublicSiteVerificationFileQueryHandler(BlogDbContext db)
+    : IQueryHandler<GetPublicSiteVerificationFileQuery, PublicSiteVerificationFile>
+{
+    public async Task<PublicSiteVerificationFile> HandleAsync(GetPublicSiteVerificationFileQuery request, CancellationToken ct)
+    {
+        var validation = SiteVerificationFileConstants.ValidateFileName(request.FileName);
+        if (!validation.Succeeded) return null;
+
+        var normalizedFileName = SiteVerificationFileConstants.NormalizeFileName(request.FileName);
+        var file = await db.SiteVerificationFile
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.NormalizedFileName == normalizedFileName && f.IsEnabled, ct);
+
+        return file == null ? null : SiteVerificationFileMapper.ToPublicFile(file);
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/GetSiteVerificationFileQuery.cs
+++ b/src/Moonglade.Features/SiteVerification/GetSiteVerificationFileQuery.cs
@@ -1,0 +1,18 @@
+using LiteBus.Queries.Abstractions;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record GetSiteVerificationFileQuery(Guid Id) : IQuery<SiteVerificationFileDetail>;
+
+public class GetSiteVerificationFileQueryHandler(BlogDbContext db)
+    : IQueryHandler<GetSiteVerificationFileQuery, SiteVerificationFileDetail>
+{
+    public async Task<SiteVerificationFileDetail> HandleAsync(GetSiteVerificationFileQuery request, CancellationToken ct)
+    {
+        var file = await db.SiteVerificationFile
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == request.Id, ct);
+
+        return file == null ? null : SiteVerificationFileMapper.ToDetail(file);
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/ListSiteVerificationFilesQuery.cs
+++ b/src/Moonglade.Features/SiteVerification/ListSiteVerificationFilesQuery.cs
@@ -1,0 +1,19 @@
+using LiteBus.Queries.Abstractions;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record ListSiteVerificationFilesQuery : IQuery<List<SiteVerificationFileSummary>>;
+
+public class ListSiteVerificationFilesQueryHandler(BlogDbContext db)
+    : IQueryHandler<ListSiteVerificationFilesQuery, List<SiteVerificationFileSummary>>
+{
+    public async Task<List<SiteVerificationFileSummary>> HandleAsync(ListSiteVerificationFilesQuery request, CancellationToken ct)
+    {
+        var files = await db.SiteVerificationFile
+            .AsNoTracking()
+            .OrderBy(f => f.FileName)
+            .ToListAsync(ct);
+
+        return files.Select(SiteVerificationFileMapper.ToSummary).ToList();
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/SiteVerificationFileConstants.cs
+++ b/src/Moonglade.Features/SiteVerification/SiteVerificationFileConstants.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Moonglade.Features.SiteVerification;
+
+public static partial class SiteVerificationFileConstants
+{
+    public const int MaxFileNameLength = 128;
+    public const int MaxContentBytes = 64 * 1024;
+
+    private static readonly HashSet<string> ReservedFileNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "android-icon.png",
+        "apple-icon.png",
+        "favicon.ico",
+        "foaf.xml",
+        "manifest.webmanifest",
+        "opensearch",
+        "robots.txt",
+        "sitemap.xml"
+    };
+
+    private static readonly Dictionary<string, string> ContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".txt"] = "text/plain; charset=utf-8",
+        [".html"] = "text/html; charset=utf-8",
+        [".htm"] = "text/html; charset=utf-8",
+        [".xml"] = "application/xml; charset=utf-8",
+        [".json"] = "application/json; charset=utf-8"
+    };
+
+    public static SiteVerificationFileValidationResult Validate(string fileName, string content)
+    {
+        var fileNameResult = ValidateFileName(fileName);
+        if (!fileNameResult.Succeeded) return fileNameResult;
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return SiteVerificationFileValidationResult.Failure("File content is required.");
+        }
+
+        var contentBytes = Encoding.UTF8.GetByteCount(content);
+        if (contentBytes > MaxContentBytes)
+        {
+            return SiteVerificationFileValidationResult.Failure("File content cannot exceed 64 KB.");
+        }
+
+        return SiteVerificationFileValidationResult.Success();
+    }
+
+    public static SiteVerificationFileValidationResult ValidateFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return SiteVerificationFileValidationResult.Failure("File name is required.");
+        }
+
+        if (fileName.Length > MaxFileNameLength)
+        {
+            return SiteVerificationFileValidationResult.Failure("File name cannot exceed 128 characters.");
+        }
+
+        if (Path.GetFileName(fileName) != fileName)
+        {
+            return SiteVerificationFileValidationResult.Failure("File name must be a root-level file name.");
+        }
+
+        if (fileName.Contains("..", StringComparison.Ordinal))
+        {
+            return SiteVerificationFileValidationResult.Failure("File name cannot contain path traversal segments.");
+        }
+
+        if (!AllowedFileNameRegex().IsMatch(fileName))
+        {
+            return SiteVerificationFileValidationResult.Failure("File name can only contain letters, digits, dots, underscores, and hyphens.");
+        }
+
+        if (fileName.EndsWith(".", StringComparison.Ordinal))
+        {
+            return SiteVerificationFileValidationResult.Failure("File name cannot end with a dot.");
+        }
+
+        if (ReservedFileNames.Contains(fileName))
+        {
+            return SiteVerificationFileValidationResult.Failure("File name is reserved by the application.");
+        }
+
+        if (!ContentTypes.ContainsKey(Path.GetExtension(fileName)))
+        {
+            return SiteVerificationFileValidationResult.Failure("Unsupported file type.");
+        }
+
+        return SiteVerificationFileValidationResult.Success();
+    }
+
+    public static string NormalizeFileName(string fileName) => fileName.ToLowerInvariant();
+
+    public static string GetContentType(string fileName) => ContentTypes[Path.GetExtension(fileName)];
+
+    [GeneratedRegex("^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$", RegexOptions.CultureInvariant)]
+    private static partial Regex AllowedFileNameRegex();
+}
+
+public sealed record SiteVerificationFileValidationResult(bool Succeeded, string ErrorMessage)
+{
+    public static SiteVerificationFileValidationResult Success() => new(true, null);
+
+    public static SiteVerificationFileValidationResult Failure(string errorMessage) => new(false, errorMessage);
+}

--- a/src/Moonglade.Features/SiteVerification/SiteVerificationFileModels.cs
+++ b/src/Moonglade.Features/SiteVerification/SiteVerificationFileModels.cs
@@ -1,0 +1,92 @@
+namespace Moonglade.Features.SiteVerification;
+
+public sealed record SiteVerificationFileSummary(
+    Guid Id,
+    string FileName,
+    string ContentType,
+    int ContentBytes,
+    bool IsEnabled,
+    DateTime CreatedTimeUtc,
+    DateTime LastModifiedTimeUtc);
+
+public sealed record SiteVerificationFileDetail(
+    Guid Id,
+    string FileName,
+    string Content,
+    string ContentType,
+    int ContentBytes,
+    bool IsEnabled,
+    DateTime CreatedTimeUtc,
+    DateTime LastModifiedTimeUtc);
+
+public sealed record PublicSiteVerificationFile(
+    string FileName,
+    string Content,
+    string ContentType,
+    DateTime LastModifiedTimeUtc,
+    string EntityTag);
+
+public enum SiteVerificationFileOperationCode
+{
+    None,
+    Done,
+    ObjectNotFound,
+    DuplicateFileName,
+    ValidationFailed
+}
+
+public sealed record SiteVerificationFileCommandResult(
+    SiteVerificationFileOperationCode Code,
+    SiteVerificationFileDetail File,
+    string ErrorMessage)
+{
+    public static SiteVerificationFileCommandResult Done(SiteVerificationFileEntity entity) =>
+        new(SiteVerificationFileOperationCode.Done, SiteVerificationFileMapper.ToDetail(entity), null);
+
+    public static SiteVerificationFileCommandResult DuplicateFileName() =>
+        new(SiteVerificationFileOperationCode.DuplicateFileName, null, "A site verification file with the same name already exists.");
+
+    public static SiteVerificationFileCommandResult ObjectNotFound() =>
+        new(SiteVerificationFileOperationCode.ObjectNotFound, null, "Site verification file was not found.");
+
+    public static SiteVerificationFileCommandResult ValidationFailed(string errorMessage) =>
+        new(SiteVerificationFileOperationCode.ValidationFailed, null, errorMessage);
+}
+
+internal static class SiteVerificationFileMapper
+{
+    public static SiteVerificationFileSummary ToSummary(SiteVerificationFileEntity entity) =>
+        new(
+            entity.Id,
+            entity.FileName,
+            entity.ContentType,
+            Encoding.UTF8.GetByteCount(entity.Content),
+            entity.IsEnabled,
+            entity.CreatedTimeUtc,
+            entity.LastModifiedTimeUtc);
+
+    public static SiteVerificationFileDetail ToDetail(SiteVerificationFileEntity entity) =>
+        new(
+            entity.Id,
+            entity.FileName,
+            entity.Content,
+            entity.ContentType,
+            Encoding.UTF8.GetByteCount(entity.Content),
+            entity.IsEnabled,
+            entity.CreatedTimeUtc,
+            entity.LastModifiedTimeUtc);
+
+    public static PublicSiteVerificationFile ToPublicFile(SiteVerificationFileEntity entity) =>
+        new(
+            entity.FileName,
+            entity.Content,
+            entity.ContentType,
+            entity.LastModifiedTimeUtc,
+            CreateEntityTag(entity));
+
+    private static string CreateEntityTag(SiteVerificationFileEntity entity)
+    {
+        var contentBytes = Encoding.UTF8.GetByteCount(entity.Content);
+        return $"\"{entity.LastModifiedTimeUtc.Ticks:x}-{contentBytes:x}\"";
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/ToggleSiteVerificationFileCommand.cs
+++ b/src/Moonglade.Features/SiteVerification/ToggleSiteVerificationFileCommand.cs
@@ -1,0 +1,29 @@
+using LiteBus.Commands.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record ToggleSiteVerificationFileCommand(Guid Id, bool IsEnabled) : ICommand<OperationCode>;
+
+public class ToggleSiteVerificationFileCommandHandler(
+    BlogDbContext db,
+    ILogger<ToggleSiteVerificationFileCommandHandler> logger)
+    : ICommandHandler<ToggleSiteVerificationFileCommand, OperationCode>
+{
+    public async Task<OperationCode> HandleAsync(ToggleSiteVerificationFileCommand request, CancellationToken ct)
+    {
+        var entity = await db.SiteVerificationFile.FirstOrDefaultAsync(f => f.Id == request.Id, ct);
+        if (entity == null) return OperationCode.ObjectNotFound;
+
+        entity.IsEnabled = request.IsEnabled;
+        entity.LastModifiedTimeUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Updated site verification file enabled state: {FileId}, {IsEnabled}",
+            request.Id,
+            request.IsEnabled);
+        return OperationCode.Done;
+    }
+}

--- a/src/Moonglade.Features/SiteVerification/UpdateSiteVerificationFileCommand.cs
+++ b/src/Moonglade.Features/SiteVerification/UpdateSiteVerificationFileCommand.cs
@@ -1,0 +1,45 @@
+using LiteBus.Commands.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Moonglade.Features.SiteVerification;
+
+public record UpdateSiteVerificationFileCommand(Guid Id, string FileName, string Content, bool IsEnabled)
+    : ICommand<SiteVerificationFileCommandResult>;
+
+public class UpdateSiteVerificationFileCommandHandler(
+    BlogDbContext db,
+    ILogger<UpdateSiteVerificationFileCommandHandler> logger)
+    : ICommandHandler<UpdateSiteVerificationFileCommand, SiteVerificationFileCommandResult>
+{
+    public async Task<SiteVerificationFileCommandResult> HandleAsync(UpdateSiteVerificationFileCommand request, CancellationToken ct)
+    {
+        var validation = SiteVerificationFileConstants.Validate(request.FileName, request.Content);
+        if (!validation.Succeeded)
+        {
+            return SiteVerificationFileCommandResult.ValidationFailed(validation.ErrorMessage);
+        }
+
+        var entity = await db.SiteVerificationFile.FirstOrDefaultAsync(f => f.Id == request.Id, ct);
+        if (entity == null) return SiteVerificationFileCommandResult.ObjectNotFound();
+
+        var normalizedFileName = SiteVerificationFileConstants.NormalizeFileName(request.FileName);
+        var duplicateExists = await db.SiteVerificationFile
+            .AnyAsync(f => f.Id != request.Id && f.NormalizedFileName == normalizedFileName, ct);
+        if (duplicateExists)
+        {
+            return SiteVerificationFileCommandResult.DuplicateFileName();
+        }
+
+        entity.FileName = request.FileName;
+        entity.NormalizedFileName = normalizedFileName;
+        entity.Content = request.Content;
+        entity.ContentType = SiteVerificationFileConstants.GetContentType(request.FileName);
+        entity.IsEnabled = request.IsEnabled;
+        entity.LastModifiedTimeUtc = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation("Updated site verification file: {FileName}", entity.FileName);
+        return SiteVerificationFileCommandResult.Done(entity);
+    }
+}

--- a/src/Moonglade.Setup/MigrationScripts/PostgreSql/migration.sql
+++ b/src/Moonglade.Setup/MigrationScripts/PostgreSql/migration.sql
@@ -79,3 +79,20 @@ CREATE TABLE IF NOT EXISTS "EmailOutboxMessage" (
 
 CREATE INDEX IF NOT EXISTS "IX_EmailOutboxMessage_Dequeue"
 ON "EmailOutboxMessage" ("Status", "NotBeforeUtc", "LockedUntilUtc", "CreatedTimeUtc");
+
+-- v16.4
+-- Add site verification files table
+CREATE TABLE IF NOT EXISTS "SiteVerificationFile" (
+    "Id" UUID NOT NULL,
+    "FileName" VARCHAR(128) NOT NULL,
+    "NormalizedFileName" VARCHAR(128) NOT NULL,
+    "Content" VARCHAR(65536) NOT NULL,
+    "ContentType" VARCHAR(64) NOT NULL,
+    "IsEnabled" BOOLEAN NOT NULL,
+    "CreatedTimeUtc" TIMESTAMP NOT NULL,
+    "LastModifiedTimeUtc" TIMESTAMP NOT NULL,
+    PRIMARY KEY ("Id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_SiteVerificationFile_NormalizedFileName"
+ON "SiteVerificationFile" ("NormalizedFileName");

--- a/src/Moonglade.Setup/MigrationScripts/SqlServer/migration.sql
+++ b/src/Moonglade.Setup/MigrationScripts/SqlServer/migration.sql
@@ -139,3 +139,31 @@ BEGIN
     ON [dbo].[EmailOutboxMessage]([Status], [NotBeforeUtc], [LockedUntilUtc], [CreatedTimeUtc]);
 END
 GO
+
+-- v16.4
+-- Add site verification files table
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[SiteVerificationFile]') AND type in (N'U'))
+BEGIN
+    CREATE TABLE [dbo].[SiteVerificationFile](
+        [Id] [uniqueidentifier] NOT NULL,
+        [FileName] [nvarchar](128) NOT NULL,
+        [NormalizedFileName] [nvarchar](128) NOT NULL,
+        [Content] [nvarchar](max) NOT NULL,
+        [ContentType] [nvarchar](64) NOT NULL,
+        [IsEnabled] [bit] NOT NULL,
+        [CreatedTimeUtc] [datetime] NOT NULL,
+        [LastModifiedTimeUtc] [datetime] NOT NULL,
+        CONSTRAINT [PK_SiteVerificationFile] PRIMARY KEY CLUSTERED
+        (
+            [Id] ASC
+        )
+    ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[SiteVerificationFile]') AND name = N'IX_SiteVerificationFile_NormalizedFileName')
+BEGIN
+    CREATE UNIQUE INDEX [IX_SiteVerificationFile_NormalizedFileName]
+    ON [dbo].[SiteVerificationFile]([NormalizedFileName]);
+END
+GO

--- a/src/Moonglade.Web/Controllers/SiteVerificationFilesController.cs
+++ b/src/Moonglade.Web/Controllers/SiteVerificationFilesController.cs
@@ -1,0 +1,166 @@
+using LiteBus.Commands.Abstractions;
+using LiteBus.Queries.Abstractions;
+using Moonglade.ActivityLog;
+using Moonglade.Features.SiteVerification;
+using Moonglade.Web.Handlers;
+using System.ComponentModel.DataAnnotations;
+
+namespace Moonglade.Web.Controllers;
+
+[Route("api/site-verification-files")]
+public class SiteVerificationFilesController(
+    ICacheAside cache,
+    IQueryMediator queryMediator,
+    ICommandMediator commandMediator) : BlogControllerBase(commandMediator)
+{
+    [HttpGet("list")]
+    public async Task<IActionResult> List()
+    {
+        var files = await queryMediator.QueryAsync(new ListSiteVerificationFilesQuery());
+        return Ok(files);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> Get([NotEmpty] Guid id)
+    {
+        var file = await queryMediator.QueryAsync(new GetSiteVerificationFileQuery(id));
+        if (file == null) return NotFound();
+
+        return Ok(file);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(SaveSiteVerificationFileRequest request)
+    {
+        var result = await CommandMediator.SendAsync(new CreateSiteVerificationFileCommand(
+            request.FileName,
+            request.Content,
+            request.IsEnabled));
+
+        if (result.Code == SiteVerificationFileOperationCode.ValidationFailed)
+        {
+            return ValidationProblem(result.ErrorMessage);
+        }
+
+        if (result.Code == SiteVerificationFileOperationCode.DuplicateFileName)
+        {
+            return Conflict(result.ErrorMessage);
+        }
+
+        RemoveVerificationFileCache(result.File.FileName);
+
+        await LogActivityAsync(
+            EventType.SiteVerificationFileCreated,
+            "Create Site Verification File",
+            result.File.FileName,
+            ActivityLogMetaData.Create(
+                ("FileName", result.File.FileName),
+                ("ContentType", result.File.ContentType),
+                ("ContentBytes", result.File.ContentBytes),
+                ("IsEnabled", result.File.IsEnabled)));
+
+        return Created($"/{result.File.FileName}", result.File);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update([NotEmpty] Guid id, SaveSiteVerificationFileRequest request)
+    {
+        var existingFile = await queryMediator.QueryAsync(new GetSiteVerificationFileQuery(id));
+        if (existingFile == null) return NotFound();
+
+        var result = await CommandMediator.SendAsync(new UpdateSiteVerificationFileCommand(
+            id,
+            request.FileName,
+            request.Content,
+            request.IsEnabled));
+
+        if (result.Code == SiteVerificationFileOperationCode.ValidationFailed)
+        {
+            return ValidationProblem(result.ErrorMessage);
+        }
+
+        if (result.Code == SiteVerificationFileOperationCode.DuplicateFileName)
+        {
+            return Conflict(result.ErrorMessage);
+        }
+
+        RemoveVerificationFileCache(existingFile.FileName);
+        RemoveVerificationFileCache(result.File.FileName);
+
+        await LogActivityAsync(
+            EventType.SiteVerificationFileUpdated,
+            "Update Site Verification File",
+            result.File.FileName,
+            ActivityLogMetaData.Create(
+                ("FileId", id),
+                ("OldFileName", existingFile.FileName),
+                ("FileName", result.File.FileName),
+                ("ContentType", result.File.ContentType),
+                ("ContentBytes", result.File.ContentBytes),
+                ("IsEnabled", result.File.IsEnabled)));
+
+        return Ok(result.File);
+    }
+
+    [HttpPost("{id:guid}/toggle")]
+    public async Task<IActionResult> Toggle([NotEmpty] Guid id, ToggleSiteVerificationFileRequest request)
+    {
+        var existingFile = await queryMediator.QueryAsync(new GetSiteVerificationFileQuery(id));
+        if (existingFile == null) return NotFound();
+
+        var oc = await CommandMediator.SendAsync(new ToggleSiteVerificationFileCommand(id, request.IsEnabled));
+        if (oc == OperationCode.ObjectNotFound) return NotFound();
+
+        RemoveVerificationFileCache(existingFile.FileName);
+
+        await LogActivityAsync(
+            EventType.SiteVerificationFileToggled,
+            "Toggle Site Verification File",
+            existingFile.FileName,
+            ActivityLogMetaData.Create(
+                ("FileId", id),
+                ("FileName", existingFile.FileName),
+                ("IsEnabled", request.IsEnabled)));
+
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete([NotEmpty] Guid id)
+    {
+        var existingFile = await queryMediator.QueryAsync(new GetSiteVerificationFileQuery(id));
+        if (existingFile == null) return NotFound();
+
+        var oc = await CommandMediator.SendAsync(new DeleteSiteVerificationFileCommand(id));
+        if (oc == OperationCode.ObjectNotFound) return NotFound();
+
+        RemoveVerificationFileCache(existingFile.FileName);
+
+        await LogActivityAsync(
+            EventType.SiteVerificationFileDeleted,
+            "Delete Site Verification File",
+            existingFile.FileName,
+            ActivityLogMetaData.Create(
+                ("FileId", id),
+                ("FileName", existingFile.FileName),
+                ("ContentType", existingFile.ContentType),
+                ("ContentBytes", existingFile.ContentBytes)));
+
+        return NoContent();
+    }
+
+    private void RemoveVerificationFileCache(string fileName) =>
+        cache.Remove(BlogCachePartition.General.ToString(), SiteVerificationFileMapHandler.GetCacheKey(fileName));
+}
+
+public sealed record SaveSiteVerificationFileRequest(
+    [Required]
+    [MaxLength(SiteVerificationFileConstants.MaxFileNameLength)]
+    string FileName,
+
+    [Required]
+    string Content,
+
+    bool IsEnabled);
+
+public sealed record ToggleSiteVerificationFileRequest(bool IsEnabled);

--- a/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
+++ b/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
@@ -72,7 +72,7 @@ public static class WebApplicationExtensions
         }
 
         app.MapMethods(
-            """/{filename:regex(^[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}\.(txt|html|htm|xml|json)$)}""",
+            """/{filename:maxlength(128):regex(^[A-Za-z0-9][A-Za-z0-9._-]*\.(txt|html|htm|xml|json)$)}""",
             ["GET", "HEAD"],
             SiteVerificationFileMapHandler.Handler);
 

--- a/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
+++ b/src/Moonglade.Web/Extensions/WebApplicationExtensions.cs
@@ -71,6 +71,11 @@ public static class WebApplicationExtensions
             app.MapGet("/sitemap.xml", SiteMapMapHandler.Handler);
         }
 
+        app.MapMethods(
+            """/{filename:regex(^[A-Za-z0-9][A-Za-z0-9._-]{{0,127}}\.(txt|html|htm|xml|json)$)}""",
+            ["GET", "HEAD"],
+            SiteVerificationFileMapHandler.Handler);
+
         return app;
     }
 }

--- a/src/Moonglade.Web/Handlers/SiteVerificationFileMapHandler.cs
+++ b/src/Moonglade.Web/Handlers/SiteVerificationFileMapHandler.cs
@@ -34,8 +34,8 @@ public class SiteVerificationFileMapHandler
         }
 
         var entityTag = EntityTagHeaderValue.Parse(file.EntityTag);
-        var lastModified = new DateTimeOffset(
-            TruncateToSeconds(DateTime.SpecifyKind(file.LastModifiedTimeUtc, DateTimeKind.Utc)));
+        var preciseLastModified = new DateTimeOffset(DateTime.SpecifyKind(file.LastModifiedTimeUtc, DateTimeKind.Utc));
+        var responseLastModified = new DateTimeOffset(TruncateToSeconds(preciseLastModified.UtcDateTime), TimeSpan.Zero);
 
         var typedHeaders = httpContext.Response.GetTypedHeaders();
         typedHeaders.CacheControl = new CacheControlHeaderValue
@@ -44,9 +44,9 @@ public class SiteVerificationFileMapHandler
             MaxAge = TimeSpan.FromMinutes(5)
         };
         typedHeaders.ETag = entityTag;
-        typedHeaders.LastModified = lastModified;
+        typedHeaders.LastModified = responseLastModified;
 
-        if (IsNotModified(httpContext, entityTag, lastModified))
+        if (IsNotModified(httpContext, entityTag, preciseLastModified))
         {
             return Results.StatusCode(StatusCodes.Status304NotModified);
         }

--- a/src/Moonglade.Web/Handlers/SiteVerificationFileMapHandler.cs
+++ b/src/Moonglade.Web/Handlers/SiteVerificationFileMapHandler.cs
@@ -1,0 +1,91 @@
+using LiteBus.Queries.Abstractions;
+using Microsoft.Net.Http.Headers;
+using Moonglade.Features.SiteVerification;
+
+namespace Moonglade.Web.Handlers;
+
+public class SiteVerificationFileMapHandler
+{
+    private const string CacheKeyPrefix = "site-verification-file:";
+
+    public static Delegate Handler => Handle;
+
+    public static async Task<IResult> Handle(
+        string filename,
+        HttpContext httpContext,
+        ICacheAside cache,
+        IQueryMediator queryMediator)
+    {
+        var validation = SiteVerificationFileConstants.ValidateFileName(filename);
+        if (!validation.Succeeded)
+        {
+            return Results.NotFound();
+        }
+
+        var cacheKey = GetCacheKey(filename);
+        var file = await cache.GetOrCreateAsync(BlogCachePartition.General.ToString(), cacheKey, async () =>
+            await queryMediator.QueryAsync(
+                new GetPublicSiteVerificationFileQuery(filename),
+                cancellationToken: httpContext.RequestAborted));
+
+        if (file == null)
+        {
+            return Results.NotFound();
+        }
+
+        var entityTag = EntityTagHeaderValue.Parse(file.EntityTag);
+        var lastModified = new DateTimeOffset(
+            TruncateToSeconds(DateTime.SpecifyKind(file.LastModifiedTimeUtc, DateTimeKind.Utc)));
+
+        var typedHeaders = httpContext.Response.GetTypedHeaders();
+        typedHeaders.CacheControl = new CacheControlHeaderValue
+        {
+            Public = true,
+            MaxAge = TimeSpan.FromMinutes(5)
+        };
+        typedHeaders.ETag = entityTag;
+        typedHeaders.LastModified = lastModified;
+
+        if (IsNotModified(httpContext, entityTag, lastModified))
+        {
+            return Results.StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        if (HttpMethods.IsHead(httpContext.Request.Method))
+        {
+            httpContext.Response.ContentType = file.ContentType;
+            httpContext.Response.ContentLength = Encoding.UTF8.GetByteCount(file.Content);
+            return Results.Empty;
+        }
+
+        return Results.Text(file.Content, file.ContentType, Encoding.UTF8);
+    }
+
+    public static string GetCacheKey(string fileName) =>
+        $"{CacheKeyPrefix}{SiteVerificationFileConstants.NormalizeFileName(fileName)}";
+
+    private static bool IsNotModified(
+        HttpContext httpContext,
+        EntityTagHeaderValue entityTag,
+        DateTimeOffset lastModified)
+    {
+        var requestHeaders = httpContext.Request.GetTypedHeaders();
+
+        if (requestHeaders.IfNoneMatch is { Count: > 0 })
+        {
+            return requestHeaders.IfNoneMatch.Any(tag =>
+                string.Equals(tag.ToString(), "*", StringComparison.Ordinal) ||
+                string.Equals(tag.ToString(), entityTag.ToString(), StringComparison.Ordinal));
+        }
+
+        if (requestHeaders.IfModifiedSince.HasValue)
+        {
+            return lastModified <= requestHeaders.IfModifiedSince.Value;
+        }
+
+        return false;
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        new(value.Ticks - value.Ticks % TimeSpan.TicksPerSecond, DateTimeKind.Utc);
+}

--- a/src/Moonglade.Web/Pages/Admin/Settings/VerificationFiles.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/Settings/VerificationFiles.cshtml
@@ -1,0 +1,158 @@
+@page "/admin/settings/verification-files"
+
+@{
+    ViewBag.Title = "Verification Files";
+    ViewBag.XData = "siteVerificationFileManager";
+}
+
+@section scripts {
+    <script type="module" src="~/js/app/admin.settings.verification-files.mjs"></script>
+}
+
+<div id="localizedStrings" style="display:none"
+     data-file-created="@SharedLocalizer["Verification file created"]"
+     data-file-updated="@SharedLocalizer["Verification file updated"]"
+     data-file-deleted="@SharedLocalizer["Verification file deleted"]"
+     data-file-enabled="@SharedLocalizer["Verification file enabled"]"
+     data-file-disabled="@SharedLocalizer["Verification file disabled"]"
+     data-delete-file="@SharedLocalizer["Delete this verification file?"]"
+     data-file-loaded="@SharedLocalizer["File loaded"]"
+     data-file-read-failed="@SharedLocalizer["Could not read file"]"
+     data-url-copied="@SharedLocalizer["URL copied"]"
+     data-file-name-required="@SharedLocalizer["File name is required"]"
+     data-file-content-required="@SharedLocalizer["File content is required"]">
+</div>
+
+@section admintoolbar {
+    <partial name="_SettingsHeader" />
+}
+
+@Html.AntiForgeryToken()
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="admin-subtitle fw-bold mb-0">@SharedLocalizer["Verification Files"]</h4>
+    <button type="button" class="btn btn-outline-accent" x-on:click="initCreateFile()">
+        <i class="bi-plus-lg"></i>
+        @SharedLocalizer["New"]
+    </button>
+</div>
+
+<div x-show="isLoading"
+     class="text-muted mb-3"
+     :class="{ 'd-flex align-items-center': isLoading }">
+    <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+    <span>@SharedLocalizer["Loading verification files..."]</span>
+</div>
+
+<div x-show="!isLoading && !hasFiles" class="alert alert-info">
+    @SharedLocalizer["No verification files yet."]
+</div>
+
+<div x-show="!isLoading && hasFiles" class="table-responsive">
+    <table class="table align-middle">
+        <thead>
+        <tr>
+            <th>@SharedLocalizer["File Name"]</th>
+            <th>@SharedLocalizer["Content Type"]</th>
+            <th>@SharedLocalizer["Size"]</th>
+            <th>@SharedLocalizer["Status"]</th>
+            <th>@SharedLocalizer["Last Modified"]</th>
+            <th class="text-end">@SharedLocalizer["Actions"]</th>
+        </tr>
+        </thead>
+        <tbody>
+        <template x-for="file in files" :key="file.id">
+            <tr>
+                <td>
+                    <div class="fw-semibold" x-text="file.fileName"></div>
+                    <a class="small" :href="getFileUrl(file.fileName)" target="_blank" rel="noopener noreferrer" x-text="getFileUrl(file.fileName)"></a>
+                </td>
+                <td><code x-text="file.contentType"></code></td>
+                <td x-text="formatBytes(file.contentBytes)"></td>
+                <td>
+                    <span x-show="file.isEnabled" class="badge bg-success">@SharedLocalizer["Enabled"]</span>
+                    <span x-show="!file.isEnabled" class="badge bg-secondary">@SharedLocalizer["Disabled"]</span>
+                </td>
+                <td>
+                    <time :data-utc-label="file.lastModifiedTimeUtc" x-text="formatDate(file.lastModifiedTimeUtc)"></time>
+                </td>
+                <td class="text-end">
+                    <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-secondary" x-on:click="copyUrl(file.fileName)" title="@SharedLocalizer["Copy URL"]">
+                            <i class="bi-copy"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-accent" x-on:click="editFile(file.id)" title="@SharedLocalizer["Edit"]">
+                            <i class="bi-pen"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" x-on:click="toggleFile(file)" :title="file.isEnabled ? '@SharedLocalizer["Disable"]' : '@SharedLocalizer["Enable"]'">
+                            <i :class="file.isEnabled ? 'bi-pause-fill' : 'bi-play-fill'"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-danger" x-on:click="deleteFile(file)" title="@SharedLocalizer["Delete"]">
+                            <i class="bi-trash"></i>
+                        </button>
+                    </div>
+                </td>
+            </tr>
+        </template>
+        </tbody>
+    </table>
+</div>
+
+<div class="offcanvas offcanvas-end overflow-hidden" tabindex="-1" x-ref="editFileCanvas" aria-labelledby="editFileCanvasLabel" style="width: 560px;">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="editFileCanvasLabel" x-text="isCreateMode ? '@SharedLocalizer["New Verification File"]' : '@SharedLocalizer["Edit Verification File"]'"></h5>
+        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="@SharedLocalizer["Close"]"></button>
+    </div>
+    <div class="offcanvas-body d-flex flex-column p-0 overflow-hidden">
+        <form x-on:submit.prevent="handleSubmit()" class="d-flex flex-column h-100">
+            <div class="flex-grow-1 p-3 overflow-auto">
+                <div class="mb-3">
+                    <label for="verification-file-upload" class="form-label">@SharedLocalizer["Upload File"]</label>
+                    <input id="verification-file-upload"
+                           type="file"
+                           class="form-control"
+                           accept=".txt,.html,.htm,.xml,.json,text/plain,text/html,application/xml,application/json"
+                           x-on:change="loadSelectedFile($event)" />
+                </div>
+
+                <div class="mb-3">
+                    <label for="verification-file-name" class="form-label">@SharedLocalizer["File Name"]</label>
+                    <input id="verification-file-name"
+                           x-model.trim="formData.fileName"
+                           type="text"
+                           class="form-control"
+                           maxlength="128"
+                           placeholder="google123.html"
+                           required />
+                </div>
+
+                <div class="mb-3">
+                    <label for="verification-file-content" class="form-label">@SharedLocalizer["Content"]</label>
+                    <textarea id="verification-file-content"
+                              x-model="formData.content"
+                              class="form-control textarea-code"
+                              rows="14"
+                              maxlength="65536"
+                              spellcheck="false"
+                              required></textarea>
+                    <div class="form-text">
+                        <span x-text="formatBytes(contentBytes)"></span>
+                        <span>/ 64 KB</span>
+                    </div>
+                </div>
+
+                <div class="form-check form-switch">
+                    <input id="verification-file-enabled" x-model="formData.isEnabled" type="checkbox" class="form-check-input" />
+                    <label for="verification-file-enabled" class="form-check-label">@SharedLocalizer["Enabled"]</label>
+                </div>
+            </div>
+
+            <div class="border-top p-3 bg-light">
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-accent">@SharedLocalizer["Save"]</button>
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">@SharedLocalizer["Cancel"]</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Moonglade.Web/Pages/Admin/Settings/_SettingsHeader.cshtml
+++ b/src/Moonglade.Web/Pages/Admin/Settings/_SettingsHeader.cshtml
@@ -28,5 +28,8 @@
         <li role="presentation" class="nav-item nav-item-non-margin">
             <a class="nav-link @(currentPage == "/Admin/Settings/Advanced" ? "active" : null)" asp-page="./Advanced">@SharedLocalizer["Advanced"]</a>
         </li>
+        <li role="presentation" class="nav-item nav-item-non-margin">
+            <a class="nav-link @(currentPage == "/Admin/Settings/VerificationFiles" ? "active" : null)" asp-page="./VerificationFiles">@SharedLocalizer["Verification Files"]</a>
+        </li>
     </ul>
 </div>

--- a/src/Moonglade.Web/Resources/Program.de-DE.resx
+++ b/src/Moonglade.Web/Resources/Program.de-DE.resx
@@ -1914,4 +1914,79 @@
   <data name="Test email is queued." xml:space="preserve">
     <value>Test-E-Mail wurde in die Warteschlange gestellt.</value>
   </data>
+  <data name="Verification Files" xml:space="preserve">
+    <value>Bestätigungsdateien</value>
+  </data>
+  <data name="Verification file created" xml:space="preserve">
+    <value>Bestätigungsdatei wurde erstellt.</value>
+  </data>
+  <data name="Verification file updated" xml:space="preserve">
+    <value>Bestätigungsdatei wurde aktualisiert.</value>
+  </data>
+  <data name="Verification file deleted" xml:space="preserve">
+    <value>Bestätigungsdatei wurde gelöscht.</value>
+  </data>
+  <data name="Verification file enabled" xml:space="preserve">
+    <value>Bestätigungsdatei wurde aktiviert.</value>
+  </data>
+  <data name="Verification file disabled" xml:space="preserve">
+    <value>Bestätigungsdatei wurde deaktiviert.</value>
+  </data>
+  <data name="Delete this verification file?" xml:space="preserve">
+    <value>Diese Bestätigungsdatei löschen?</value>
+  </data>
+  <data name="File loaded" xml:space="preserve">
+    <value>Datei geladen.</value>
+  </data>
+  <data name="Could not read file" xml:space="preserve">
+    <value>Datei konnte nicht gelesen werden.</value>
+  </data>
+  <data name="URL copied" xml:space="preserve">
+    <value>URL kopiert.</value>
+  </data>
+  <data name="File name is required" xml:space="preserve">
+    <value>Dateiname ist erforderlich.</value>
+  </data>
+  <data name="File content is required" xml:space="preserve">
+    <value>Dateiinhalt ist erforderlich.</value>
+  </data>
+  <data name="Loading verification files..." xml:space="preserve">
+    <value>Bestätigungsdateien werden geladen...</value>
+  </data>
+  <data name="No verification files yet." xml:space="preserve">
+    <value>Noch keine Bestätigungsdateien.</value>
+  </data>
+  <data name="File Name" xml:space="preserve">
+    <value>Dateiname</value>
+  </data>
+  <data name="Content Type" xml:space="preserve">
+    <value>Inhaltstyp</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>Größe</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Last Modified" xml:space="preserve">
+    <value>Zuletzt geändert</value>
+  </data>
+  <data name="Copy URL" xml:space="preserve">
+    <value>URL kopieren</value>
+  </data>
+  <data name="Disable" xml:space="preserve">
+    <value>Deaktivieren</value>
+  </data>
+  <data name="Enable" xml:space="preserve">
+    <value>Aktivieren</value>
+  </data>
+  <data name="New Verification File" xml:space="preserve">
+    <value>Neue Bestätigungsdatei</value>
+  </data>
+  <data name="Edit Verification File" xml:space="preserve">
+    <value>Bestätigungsdatei bearbeiten</value>
+  </data>
+  <data name="Upload File" xml:space="preserve">
+    <value>Datei hochladen</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.ja-JP.resx
+++ b/src/Moonglade.Web/Resources/Program.ja-JP.resx
@@ -1914,4 +1914,79 @@
   <data name="Test email is queued." xml:space="preserve">
     <value>テストメールをキューに追加しました。</value>
   </data>
+  <data name="Verification Files" xml:space="preserve">
+    <value>認証ファイル</value>
+  </data>
+  <data name="Verification file created" xml:space="preserve">
+    <value>認証ファイルを作成しました。</value>
+  </data>
+  <data name="Verification file updated" xml:space="preserve">
+    <value>認証ファイルを更新しました。</value>
+  </data>
+  <data name="Verification file deleted" xml:space="preserve">
+    <value>認証ファイルを削除しました。</value>
+  </data>
+  <data name="Verification file enabled" xml:space="preserve">
+    <value>認証ファイルを有効にしました。</value>
+  </data>
+  <data name="Verification file disabled" xml:space="preserve">
+    <value>認証ファイルを無効にしました。</value>
+  </data>
+  <data name="Delete this verification file?" xml:space="preserve">
+    <value>この認証ファイルを削除しますか？</value>
+  </data>
+  <data name="File loaded" xml:space="preserve">
+    <value>ファイルを読み込みました。</value>
+  </data>
+  <data name="Could not read file" xml:space="preserve">
+    <value>ファイルを読み取れませんでした。</value>
+  </data>
+  <data name="URL copied" xml:space="preserve">
+    <value>URL をコピーしました。</value>
+  </data>
+  <data name="File name is required" xml:space="preserve">
+    <value>ファイル名は必須です。</value>
+  </data>
+  <data name="File content is required" xml:space="preserve">
+    <value>ファイル内容は必須です。</value>
+  </data>
+  <data name="Loading verification files..." xml:space="preserve">
+    <value>認証ファイルを読み込んでいます...</value>
+  </data>
+  <data name="No verification files yet." xml:space="preserve">
+    <value>認証ファイルはまだありません。</value>
+  </data>
+  <data name="File Name" xml:space="preserve">
+    <value>ファイル名</value>
+  </data>
+  <data name="Content Type" xml:space="preserve">
+    <value>コンテンツタイプ</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>サイズ</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>状態</value>
+  </data>
+  <data name="Last Modified" xml:space="preserve">
+    <value>最終更新</value>
+  </data>
+  <data name="Copy URL" xml:space="preserve">
+    <value>URL をコピー</value>
+  </data>
+  <data name="Disable" xml:space="preserve">
+    <value>無効化</value>
+  </data>
+  <data name="Enable" xml:space="preserve">
+    <value>有効化</value>
+  </data>
+  <data name="New Verification File" xml:space="preserve">
+    <value>新しい認証ファイル</value>
+  </data>
+  <data name="Edit Verification File" xml:space="preserve">
+    <value>認証ファイルを編集</value>
+  </data>
+  <data name="Upload File" xml:space="preserve">
+    <value>ファイルをアップロード</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.zh-Hans.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hans.resx
@@ -1914,4 +1914,79 @@
   <data name="Test email is queued." xml:space="preserve">
     <value>测试邮件已加入队列。</value>
   </data>
+  <data name="Verification Files" xml:space="preserve">
+    <value>验证文件</value>
+  </data>
+  <data name="Verification file created" xml:space="preserve">
+    <value>验证文件已创建</value>
+  </data>
+  <data name="Verification file updated" xml:space="preserve">
+    <value>验证文件已更新</value>
+  </data>
+  <data name="Verification file deleted" xml:space="preserve">
+    <value>验证文件已删除</value>
+  </data>
+  <data name="Verification file enabled" xml:space="preserve">
+    <value>验证文件已启用</value>
+  </data>
+  <data name="Verification file disabled" xml:space="preserve">
+    <value>验证文件已禁用</value>
+  </data>
+  <data name="Delete this verification file?" xml:space="preserve">
+    <value>要删除这个验证文件吗？</value>
+  </data>
+  <data name="File loaded" xml:space="preserve">
+    <value>文件已载入</value>
+  </data>
+  <data name="Could not read file" xml:space="preserve">
+    <value>无法读取文件</value>
+  </data>
+  <data name="URL copied" xml:space="preserve">
+    <value>URL 已复制</value>
+  </data>
+  <data name="File name is required" xml:space="preserve">
+    <value>文件名必填</value>
+  </data>
+  <data name="File content is required" xml:space="preserve">
+    <value>文件内容必填</value>
+  </data>
+  <data name="Loading verification files..." xml:space="preserve">
+    <value>正在加载验证文件...</value>
+  </data>
+  <data name="No verification files yet." xml:space="preserve">
+    <value>还没有验证文件。</value>
+  </data>
+  <data name="File Name" xml:space="preserve">
+    <value>文件名</value>
+  </data>
+  <data name="Content Type" xml:space="preserve">
+    <value>内容类型</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>大小</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="Last Modified" xml:space="preserve">
+    <value>最后修改</value>
+  </data>
+  <data name="Copy URL" xml:space="preserve">
+    <value>复制 URL</value>
+  </data>
+  <data name="Disable" xml:space="preserve">
+    <value>禁用</value>
+  </data>
+  <data name="Enable" xml:space="preserve">
+    <value>启用</value>
+  </data>
+  <data name="New Verification File" xml:space="preserve">
+    <value>新建验证文件</value>
+  </data>
+  <data name="Edit Verification File" xml:space="preserve">
+    <value>编辑验证文件</value>
+  </data>
+  <data name="Upload File" xml:space="preserve">
+    <value>上传文件</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/Resources/Program.zh-Hant.resx
+++ b/src/Moonglade.Web/Resources/Program.zh-Hant.resx
@@ -1914,4 +1914,79 @@
   <data name="Test email is queued." xml:space="preserve">
     <value>測試郵件已加入佇列。</value>
   </data>
+  <data name="Verification Files" xml:space="preserve">
+    <value>驗證檔案</value>
+  </data>
+  <data name="Verification file created" xml:space="preserve">
+    <value>驗證檔案已建立</value>
+  </data>
+  <data name="Verification file updated" xml:space="preserve">
+    <value>驗證檔案已更新</value>
+  </data>
+  <data name="Verification file deleted" xml:space="preserve">
+    <value>驗證檔案已刪除</value>
+  </data>
+  <data name="Verification file enabled" xml:space="preserve">
+    <value>驗證檔案已啟用</value>
+  </data>
+  <data name="Verification file disabled" xml:space="preserve">
+    <value>驗證檔案已停用</value>
+  </data>
+  <data name="Delete this verification file?" xml:space="preserve">
+    <value>要刪除這個驗證檔案嗎？</value>
+  </data>
+  <data name="File loaded" xml:space="preserve">
+    <value>檔案已載入</value>
+  </data>
+  <data name="Could not read file" xml:space="preserve">
+    <value>無法讀取檔案</value>
+  </data>
+  <data name="URL copied" xml:space="preserve">
+    <value>URL 已複製</value>
+  </data>
+  <data name="File name is required" xml:space="preserve">
+    <value>檔案名稱必填</value>
+  </data>
+  <data name="File content is required" xml:space="preserve">
+    <value>檔案內容必填</value>
+  </data>
+  <data name="Loading verification files..." xml:space="preserve">
+    <value>正在載入驗證檔案...</value>
+  </data>
+  <data name="No verification files yet." xml:space="preserve">
+    <value>還沒有驗證檔案。</value>
+  </data>
+  <data name="File Name" xml:space="preserve">
+    <value>檔案名稱</value>
+  </data>
+  <data name="Content Type" xml:space="preserve">
+    <value>內容類型</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>大小</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>狀態</value>
+  </data>
+  <data name="Last Modified" xml:space="preserve">
+    <value>最後修改</value>
+  </data>
+  <data name="Copy URL" xml:space="preserve">
+    <value>複製 URL</value>
+  </data>
+  <data name="Disable" xml:space="preserve">
+    <value>停用</value>
+  </data>
+  <data name="Enable" xml:space="preserve">
+    <value>啟用</value>
+  </data>
+  <data name="New Verification File" xml:space="preserve">
+    <value>新增驗證檔案</value>
+  </data>
+  <data name="Edit Verification File" xml:space="preserve">
+    <value>編輯驗證檔案</value>
+  </data>
+  <data name="Upload File" xml:space="preserve">
+    <value>上傳檔案</value>
+  </data>
 </root>

--- a/src/Moonglade.Web/wwwroot/js/app/admin.settings.verification-files.mjs
+++ b/src/Moonglade.Web/wwwroot/js/app/admin.settings.verification-files.mjs
@@ -1,0 +1,163 @@
+import { Alpine } from './alpine-init.mjs';
+import { fetch2 } from './httpService.mjs?v=1500';
+import { success, error } from './toastService.mjs';
+import { getLocalizedString } from './utils.module.mjs';
+import { showDeleteConfirmModal, hideConfirmModal } from './adminModal.mjs';
+
+const emptyFormData = () => ({
+    fileName: '',
+    content: '',
+    isEnabled: true
+});
+
+const textEncoder = new TextEncoder();
+
+Alpine.data('siteVerificationFileManager', () => ({
+    files: [],
+    isLoading: true,
+    currentFileId: window.emptyGuid,
+    editCanvas: null,
+    formData: emptyFormData(),
+
+    async init() {
+        this.editCanvas = new bootstrap.Offcanvas(this.$refs.editFileCanvas);
+        await this.loadFiles();
+    },
+
+    get hasFiles() {
+        return this.files.length > 0;
+    },
+
+    get isCreateMode() {
+        return this.currentFileId === window.emptyGuid;
+    },
+
+    get contentBytes() {
+        return textEncoder.encode(this.formData.content ?? '').length;
+    },
+
+    async loadFiles() {
+        this.isLoading = true;
+        try {
+            this.files = (await fetch2('/api/site-verification-files/list', 'GET')) ?? [];
+        } catch (err) {
+            error(err);
+        } finally {
+            this.isLoading = false;
+        }
+    },
+
+    initCreateFile() {
+        this.currentFileId = window.emptyGuid;
+        this.formData = emptyFormData();
+        this.editCanvas.show();
+    },
+
+    async editFile(id) {
+        try {
+            const file = await fetch2(`/api/site-verification-files/${id}`, 'GET');
+            this.currentFileId = file.id;
+            this.formData = {
+                fileName: file.fileName,
+                content: file.content,
+                isEnabled: file.isEnabled
+            };
+            this.editCanvas.show();
+        } catch (err) {
+            error(err);
+        }
+    },
+
+    async handleSubmit() {
+        if (!this.formData.fileName) {
+            error(getLocalizedString('fileNameRequired'));
+            return;
+        }
+
+        if (!this.formData.content || !this.formData.content.trim()) {
+            error(getLocalizedString('fileContentRequired'));
+            return;
+        }
+
+        const isCreate = this.isCreateMode;
+        const apiAddress = isCreate
+            ? '/api/site-verification-files'
+            : `/api/site-verification-files/${this.currentFileId}`;
+        const verb = isCreate ? 'POST' : 'PUT';
+
+        try {
+            await fetch2(apiAddress, verb, this.formData);
+            this.editCanvas.hide();
+            await this.loadFiles();
+            success(isCreate ? getLocalizedString('fileCreated') : getLocalizedString('fileUpdated'));
+        } catch (err) {
+            error(err);
+        }
+    },
+
+    deleteFile(file) {
+        showDeleteConfirmModal(getLocalizedString('deleteFile'), async () => {
+            try {
+                await fetch2(`/api/site-verification-files/${file.id}`, 'DELETE');
+                hideConfirmModal();
+                await this.loadFiles();
+                success(getLocalizedString('fileDeleted'));
+            } catch (err) {
+                error(err);
+            }
+        });
+    },
+
+    async toggleFile(file) {
+        try {
+            await fetch2(`/api/site-verification-files/${file.id}/toggle`, 'POST', {
+                isEnabled: !file.isEnabled
+            });
+            await this.loadFiles();
+            success(file.isEnabled ? getLocalizedString('fileDisabled') : getLocalizedString('fileEnabled'));
+        } catch (err) {
+            error(err);
+        }
+    },
+
+    async loadSelectedFile(event) {
+        const file = event.target.files?.[0];
+        if (!file) return;
+
+        try {
+            const content = await file.text();
+            this.formData.fileName = file.name;
+            this.formData.content = content;
+            success(getLocalizedString('fileLoaded'));
+        } catch (err) {
+            error(getLocalizedString('fileReadFailed'));
+        } finally {
+            event.target.value = '';
+        }
+    },
+
+    async copyUrl(fileName) {
+        try {
+            await navigator.clipboard.writeText(this.getFileUrl(fileName));
+            success(getLocalizedString('urlCopied'));
+        } catch (err) {
+            error(err);
+        }
+    },
+
+    getFileUrl(fileName) {
+        return `${window.location.origin}/${fileName}`;
+    },
+
+    formatBytes(bytes) {
+        if (bytes < 1024) return `${bytes} B`;
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    },
+
+    formatDate(dateString) {
+        if (!dateString) return '';
+        const normalized = dateString.endsWith('Z') ? dateString : `${dateString}Z`;
+        const date = new Date(normalized);
+        return isNaN(date.getTime()) ? dateString : date.toLocaleString();
+    }
+}));

--- a/src/Tests/Moonglade.Features.Tests/SiteVerificationFileTests.cs
+++ b/src/Tests/Moonglade.Features.Tests/SiteVerificationFileTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Data.Sqlite;
+using Moonglade.Data;
+using Moonglade.Data.Entities;
+using Moonglade.Features.SiteVerification;
+using Moq;
+
+namespace Moonglade.Features.Tests;
+
+public class SiteVerificationFileTests
+{
+    private static BlogDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<BlogDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new BlogDbContext(options);
+    }
+
+    [Fact]
+    public async Task CreateSiteVerificationFileCommand_CreatesFileWithNormalizedNameAndContentType()
+    {
+        using var db = CreateDbContext();
+        var handler = new CreateSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<CreateSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new CreateSiteVerificationFileCommand("Google123.HTML", "verification-token", true),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(SiteVerificationFileOperationCode.Done, result.Code);
+        Assert.Equal("Google123.HTML", result.File.FileName);
+        Assert.Equal("text/html; charset=utf-8", result.File.ContentType);
+        Assert.True(result.File.IsEnabled);
+
+        var entity = await db.SiteVerificationFile.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("google123.html", entity.NormalizedFileName);
+    }
+
+    [Fact]
+    public async Task CreateSiteVerificationFileCommand_DuplicateNormalizedFileName_ReturnsDuplicate()
+    {
+        using var db = CreateDbContext();
+        db.SiteVerificationFile.Add(CreateEntity("Google123.HTML", "google123.html"));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new CreateSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<CreateSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new CreateSiteVerificationFileCommand("google123.html", "verification-token", true),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(SiteVerificationFileOperationCode.DuplicateFileName, result.Code);
+        Assert.Single(await db.SiteVerificationFile.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CreateSiteVerificationFileCommand_InvalidFileName_ReturnsValidationFailed()
+    {
+        using var db = CreateDbContext();
+        var handler = new CreateSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<CreateSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new CreateSiteVerificationFileCommand("../google.html", "verification-token", true),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(SiteVerificationFileOperationCode.ValidationFailed, result.Code);
+        Assert.Empty(await db.SiteVerificationFile.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdateSiteVerificationFileCommand_ExistingFile_UpdatesContentAndName()
+    {
+        using var db = CreateDbContext();
+        var entity = CreateEntity("old.txt", "old.txt");
+        db.SiteVerificationFile.Add(entity);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new UpdateSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<UpdateSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new UpdateSiteVerificationFileCommand(entity.Id, "new.json", "{\"ok\":true}", false),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(SiteVerificationFileOperationCode.Done, result.Code);
+        Assert.Equal("new.json", result.File.FileName);
+        Assert.Equal("application/json; charset=utf-8", result.File.ContentType);
+        Assert.False(result.File.IsEnabled);
+
+        var saved = await db.SiteVerificationFile.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("new.json", saved.NormalizedFileName);
+        Assert.True(saved.LastModifiedTimeUtc >= entity.CreatedTimeUtc);
+    }
+
+    [Fact]
+    public async Task ToggleSiteVerificationFileCommand_ExistingFile_UpdatesEnabledState()
+    {
+        using var db = CreateDbContext();
+        var entity = CreateEntity("google.txt", "google.txt");
+        db.SiteVerificationFile.Add(entity);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new ToggleSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<ToggleSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new ToggleSiteVerificationFileCommand(entity.Id, false),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OperationCode.Done, result);
+        Assert.False((await db.SiteVerificationFile.SingleAsync(TestContext.Current.CancellationToken)).IsEnabled);
+    }
+
+    [Fact]
+    public async Task GetPublicSiteVerificationFileQuery_EnabledFile_ReturnsPublicFile()
+    {
+        using var db = CreateDbContext();
+        db.SiteVerificationFile.Add(CreateEntity("Google123.html", "google123.html"));
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new GetPublicSiteVerificationFileQueryHandler(db);
+
+        var result = await handler.HandleAsync(
+            new GetPublicSiteVerificationFileQuery("google123.html"),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("Google123.html", result.FileName);
+        Assert.Equal("verification-token", result.Content);
+        Assert.StartsWith("\"", result.EntityTag, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetPublicSiteVerificationFileQuery_DisabledFile_ReturnsNull()
+    {
+        using var db = CreateDbContext();
+        var entity = CreateEntity("google.txt", "google.txt");
+        entity.IsEnabled = false;
+        db.SiteVerificationFile.Add(entity);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new GetPublicSiteVerificationFileQueryHandler(db);
+
+        var result = await handler.HandleAsync(
+            new GetPublicSiteVerificationFileQuery("google.txt"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task DeleteSiteVerificationFileCommand_ExistingFile_RemovesFile()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        var options = new DbContextOptionsBuilder<BlogDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var db = new BlogDbContext(options);
+        await db.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        var entity = CreateEntity("google.txt", "google.txt");
+        db.SiteVerificationFile.Add(entity);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new DeleteSiteVerificationFileCommandHandler(
+            db,
+            Mock.Of<ILogger<DeleteSiteVerificationFileCommandHandler>>());
+
+        var result = await handler.HandleAsync(
+            new DeleteSiteVerificationFileCommand(entity.Id),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OperationCode.Done, result);
+        Assert.Empty(await db.SiteVerificationFile.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    private static SiteVerificationFileEntity CreateEntity(string fileName, string normalizedFileName)
+    {
+        var now = DateTime.UtcNow.AddMinutes(-1);
+        return new SiteVerificationFileEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = fileName,
+            NormalizedFileName = normalizedFileName,
+            Content = "verification-token",
+            ContentType = SiteVerificationFileConstants.GetContentType(fileName),
+            IsEnabled = true,
+            CreatedTimeUtc = now,
+            LastModifiedTimeUtc = now
+        };
+    }
+}

--- a/src/Tests/Moonglade.Web.Tests/SiteVerificationFileMapHandlerTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/SiteVerificationFileMapHandlerTests.cs
@@ -82,6 +82,32 @@ public class SiteVerificationFileMapHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenIfModifiedSinceMatchesOnlyTruncatedSecond_ReturnsOk()
+    {
+        const string fileName = "google123.txt";
+        const string content = "verification-token";
+        var preciseLastModified = new DateTime(2026, 8, 9, 1, 2, 3, 500, DateTimeKind.Utc);
+        var file = CreatePublicFile(fileName, content, preciseLastModified);
+        var cache = CreateCache(fileName, file);
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Headers.IfModifiedSince = "Sun, 09 Aug 2026 01:02:03 GMT";
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            fileName,
+            httpContext,
+            cache.Object,
+            Mock.Of<IQueryMediator>());
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+        Assert.Equal("Sun, 09 Aug 2026 01:02:03 GMT", httpContext.Response.Headers.LastModified.ToString());
+
+        var body = await ReadBodyAsync(httpContext);
+        Assert.Equal(content, body);
+    }
+
+    [Fact]
     public async Task Handle_WhenFileNameIsInvalid_ReturnsNotFoundWithoutQuery()
     {
         var cache = new Mock<ICacheAside>();
@@ -151,9 +177,12 @@ public class SiteVerificationFileMapHandlerTests
         return httpContext;
     }
 
-    private static PublicSiteVerificationFile CreatePublicFile(string fileName, string content)
+    private static PublicSiteVerificationFile CreatePublicFile(
+        string fileName,
+        string content,
+        DateTime? lastModifiedUtc = null)
     {
-        var lastModified = new DateTime(2026, 8, 9, 1, 2, 3, DateTimeKind.Utc);
+        var lastModified = lastModifiedUtc ?? new DateTime(2026, 8, 9, 1, 2, 3, DateTimeKind.Utc);
         var contentBytes = Encoding.UTF8.GetByteCount(content);
         return new PublicSiteVerificationFile(
             fileName,

--- a/src/Tests/Moonglade.Web.Tests/SiteVerificationFileMapHandlerTests.cs
+++ b/src/Tests/Moonglade.Web.Tests/SiteVerificationFileMapHandlerTests.cs
@@ -1,0 +1,172 @@
+using Edi.CacheAside.InMemory;
+using LiteBus.Queries.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moonglade.Features.SiteVerification;
+using Moonglade.Web.Handlers;
+using Moq;
+using System.Text;
+
+namespace Moonglade.Web.Tests;
+
+public class SiteVerificationFileMapHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenFileExists_ReturnsTextWithCacheHeaders()
+    {
+        const string fileName = "google123.html";
+        const string content = "verification-token";
+        var file = CreatePublicFile(fileName, content);
+        var cache = CreateCache(fileName, file);
+        var httpContext = CreateHttpContext();
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            fileName,
+            httpContext,
+            cache.Object,
+            Mock.Of<IQueryMediator>());
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+        Assert.Equal("text/html; charset=utf-8", httpContext.Response.ContentType);
+        Assert.Equal("public, max-age=300", httpContext.Response.Headers.CacheControl.ToString());
+        Assert.Equal(file.EntityTag, httpContext.Response.Headers.ETag.ToString());
+
+        var body = await ReadBodyAsync(httpContext);
+        Assert.Equal(content, body);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRequestIsHead_ReturnsHeadersWithoutBody()
+    {
+        const string fileName = "google123.txt";
+        var file = CreatePublicFile(fileName, "verification-token");
+        var cache = CreateCache(fileName, file);
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Method = HttpMethods.Head;
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            fileName,
+            httpContext,
+            cache.Object,
+            Mock.Of<IQueryMediator>());
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+        Assert.Equal("text/plain; charset=utf-8", httpContext.Response.ContentType);
+        Assert.Equal(18, httpContext.Response.ContentLength);
+        Assert.Equal(0, httpContext.Response.Body.Length);
+    }
+
+    [Fact]
+    public async Task Handle_WhenIfNoneMatchMatches_ReturnsNotModified()
+    {
+        const string fileName = "google123.txt";
+        var file = CreatePublicFile(fileName, "verification-token");
+        var cache = CreateCache(fileName, file);
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Headers.IfNoneMatch = file.EntityTag;
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            fileName,
+            httpContext,
+            cache.Object,
+            Mock.Of<IQueryMediator>());
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status304NotModified, httpContext.Response.StatusCode);
+        Assert.Equal(0, httpContext.Response.Body.Length);
+    }
+
+    [Fact]
+    public async Task Handle_WhenFileNameIsInvalid_ReturnsNotFoundWithoutQuery()
+    {
+        var cache = new Mock<ICacheAside>();
+        var queryMediator = new Mock<IQueryMediator>();
+        var httpContext = CreateHttpContext();
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            "../google.txt",
+            httpContext,
+            cache.Object,
+            queryMediator.Object);
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status404NotFound, httpContext.Response.StatusCode);
+        cache.Verify(
+            x => x.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<Task<PublicSiteVerificationFile>>>()),
+            Times.Never);
+        queryMediator.Verify(
+            x => x.QueryAsync(
+                It.IsAny<GetPublicSiteVerificationFileQuery>(),
+                It.IsAny<QueryMediationSettings>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenFileDoesNotExist_ReturnsNotFound()
+    {
+        const string fileName = "missing.txt";
+        var cache = CreateCache(fileName, null);
+        var httpContext = CreateHttpContext();
+
+        var result = await SiteVerificationFileMapHandler.Handle(
+            fileName,
+            httpContext,
+            cache.Object,
+            Mock.Of<IQueryMediator>());
+
+        await result.ExecuteAsync(httpContext);
+
+        Assert.Equal(StatusCodes.Status404NotFound, httpContext.Response.StatusCode);
+    }
+
+    private static Mock<ICacheAside> CreateCache(string fileName, PublicSiteVerificationFile? file)
+    {
+        var cache = new Mock<ICacheAside>();
+        cache
+            .Setup(x => x.GetOrCreateAsync(
+                BlogCachePartition.General.ToString(),
+                SiteVerificationFileMapHandler.GetCacheKey(fileName),
+                It.IsAny<Func<Task<PublicSiteVerificationFile>>>()))
+            .ReturnsAsync(file);
+
+        return cache;
+    }
+
+    private static DefaultHttpContext CreateHttpContext()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = HttpMethods.Get;
+        httpContext.Response.Body = new MemoryStream();
+        httpContext.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+        return httpContext;
+    }
+
+    private static PublicSiteVerificationFile CreatePublicFile(string fileName, string content)
+    {
+        var lastModified = new DateTime(2026, 8, 9, 1, 2, 3, DateTimeKind.Utc);
+        var contentBytes = Encoding.UTF8.GetByteCount(content);
+        return new PublicSiteVerificationFile(
+            fileName,
+            content,
+            SiteVerificationFileConstants.GetContentType(fileName),
+            lastModified,
+            $"\"{lastModified.Ticks:x}-{contentBytes:x}\"");
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpContext httpContext)
+    {
+        httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8, leaveOpen: true);
+        return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
Introduces end-to-end support for root-level site verification files stored in the database. This adds EF entities/configuration and migration scripts (SQL Server/PostgreSQL), feature-layer commands/queries with validation and duplicate checks, admin APIs, activity log event types, and cache invalidation.

Also maps a constrained public GET/HEAD endpoint to serve enabled verification files with ETag/Last-Modified handling, adds an admin settings page and JS module for CRUD/toggle/upload workflows, localizes new UI strings, and updates README/AGENTS guidance. Includes new feature and web tests covering command/query behavior and public handler responses.